### PR TITLE
Rename package to gh-analysis for shorter CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,26 +52,26 @@ def process_issues(issues: List[Dict[str, Any]]) -> Optional[str]:
 **CLI Usage:**
 ```bash
 # Collect GitHub issues (various modes)
-uv run github-analysis collect --org myorg --repo myrepo                    # Repository-specific
-uv run github-analysis collect --org myorg                                  # Organization-wide  
-uv run github-analysis collect --org myorg --repo myrepo --issue-number 123 # Single issue
+uv run gh-analysis collect --org myorg --repo myrepo                    # Repository-specific
+uv run gh-analysis collect --org myorg                                  # Organization-wide  
+uv run gh-analysis collect --org myorg --repo myrepo --issue-number 123 # Single issue
 
 # Show storage statistics
-uv run github-analysis status
+uv run gh-analysis status
 
 # Show version information
-uv run github-analysis version
+uv run gh-analysis version
 
 # AI processing commands (BATCH PROCESSING RECOMMENDED)
 # Use batch processing for cost-effective analysis (50% cheaper than individual processing)
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo   # Batch process all issues for repo
-uv run github-analysis batch submit product-labeling --org myorg               # Batch process all org issues
-uv run github-analysis batch status <job-id>                                   # Check batch job progress
-uv run github-analysis batch collect <job-id>                                  # Collect completed results
-uv run github-analysis batch list                                              # List all batch jobs
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo   # Batch process all issues for repo
+uv run gh-analysis batch submit product-labeling --org myorg               # Batch process all org issues
+uv run gh-analysis batch status <job-id>                                   # Check batch job progress
+uv run gh-analysis batch collect <job-id>                                  # Collect completed results
+uv run gh-analysis batch list                                              # List all batch jobs
 
 # Individual processing (use only for single issues or testing)
-uv run github-analysis process product-labeling --org myorg --repo myrepo --issue-number 123  # Single issue only
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --issue-number 123  # Single issue only
 ```
 
 ## Architecture
@@ -164,7 +164,7 @@ GITHUB_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN gh pr create --title "Title" --body "
 GITHUB_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN gh repo view
 
 # Testing the CLI tool (use GITHUB_TOKEN for test repo access)
-uv run github-analysis collect --org YOUR_ORG --repo YOUR_REPO --issue-number 123
+uv run gh-analysis collect --org YOUR_ORG --repo YOUR_REPO --issue-number 123
 ```
 
 **Why Two Tokens:**

--- a/README.md
+++ b/README.md
@@ -13,43 +13,43 @@ Collect GitHub issues and analyze them with AI to improve issue labeling and cat
 
 2. **Collect Issues**
    ```bash
-   uv run github-analysis collect --org YOUR_ORG --repo YOUR_REPO --labels bug --limit 5
+   uv run gh-analysis collect --org YOUR_ORG --repo YOUR_REPO --labels bug --limit 5
    ```
 
 3. **Process with AI (Batch Processing - Recommended)**
    ```bash
    # Submit batch job (50% cheaper than individual processing)
-   uv run github-analysis batch submit product-labeling --org YOUR_ORG --repo YOUR_REPO
+   uv run gh-analysis batch submit product-labeling --org YOUR_ORG --repo YOUR_REPO
    
    # Check status
-   uv run github-analysis batch list
+   uv run gh-analysis batch list
    
    # Collect results when completed
-   uv run github-analysis batch collect <job-id>
+   uv run gh-analysis batch collect <job-id>
    ```
 
    **Individual Processing** (for single issues or custom models):
    ```bash
    # Use default model
-   uv run github-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO --issue-number 123
+   uv run gh-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO --issue-number 123
    
    # Use custom model with settings
-   uv run github-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO \
+   uv run gh-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO \
      --model anthropic:claude-3-5-sonnet \
      --setting temperature=0.5 \
      --setting reasoning_effort=high
    
    # Show available model settings
-   uv run github-analysis process show-settings
+   uv run gh-analysis process show-settings
    ```
 
 4. **Update Labels** (with GitHub write token)
    ```bash
    # Preview changes first
-   uv run github-analysis update-labels --org YOUR_ORG --repo YOUR_REPO --dry-run
+   uv run gh-analysis update-labels --org YOUR_ORG --repo YOUR_REPO --dry-run
    
    # Apply changes
-   uv run github-analysis update-labels --org YOUR_ORG --repo YOUR_REPO
+   uv run gh-analysis update-labels --org YOUR_ORG --repo YOUR_REPO
    ```
 
 ## For AI Agents

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,9 @@ User documentation for the GitHub issue collection and AI analysis tool.
 
 1. Set up environment: `uv sync --all-extras`
 2. Configure `.env` file with API keys
-3. Collect issues: `uv run github-analysis collect --org myorg --repo myrepo`
-4. Process issues: `uv run github-analysis process product-labeling --org myorg --repo myrepo`
-5. Update labels: `uv run github-analysis update-labels --org myorg --repo myrepo --dry-run`
+3. Collect issues: `uv run gh-analysis collect --org myorg --repo myrepo`
+4. Process issues: `uv run gh-analysis process product-labeling --org myorg --repo myrepo`
+5. Update labels: `uv run gh-analysis update-labels --org myorg --repo myrepo --dry-run`
 
 ## For AI Agents
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,7 @@
 Collect GitHub issues and save them locally.
 
 ```bash
-uv run github-analysis collect [OPTIONS]
+uv run gh-analysis collect [OPTIONS]
 ```
 
 **Options:**
@@ -30,39 +30,39 @@ uv run github-analysis collect [OPTIONS]
 **Examples:**
 ```bash
 # Collect single issue
-uv run github-analysis collect --org example-org --repo example-repo --issue-number 71
+uv run gh-analysis collect --org example-org --repo example-repo --issue-number 71
 
 # Collect from entire organization (20 most recent closed issues)
-uv run github-analysis collect --org example-org --limit 20
+uv run gh-analysis collect --org example-org --limit 20
 
 # Collect bugs from specific repository
-uv run github-analysis collect --org example-org --repo example-repo --labels bug --limit 5
+uv run gh-analysis collect --org example-org --repo example-repo --labels bug --limit 5
 
 # Organization-wide collection excluding specific repositories
-uv run github-analysis collect --org example-org --exclude-repo private-repo --limit 15
+uv run gh-analysis collect --org example-org --exclude-repo private-repo --limit 15
 
 # Exclude multiple repositories using multiple flags
-uv run github-analysis collect --org example-org --exclude-repo private-repo --exclude-repo test-repo --limit 10
+uv run gh-analysis collect --org example-org --exclude-repo private-repo --exclude-repo test-repo --limit 10
 
 # Exclude multiple repositories using comma-separated list
-uv run github-analysis collect --org example-org --exclude-repos "private-repo,test-repo,archived-repo" --limit 10
+uv run gh-analysis collect --org example-org --exclude-repos "private-repo,test-repo,archived-repo" --limit 10
 
 # Mix both exclusion approaches with additional filters
-uv run github-analysis collect --org example-org --exclude-repo private-repo --exclude-repos "test-repo,docs-repo" --labels bug --state open --limit 20
+uv run gh-analysis collect --org example-org --exclude-repo private-repo --exclude-repos "test-repo,docs-repo" --labels bug --state open --limit 20
 ```
 
 ### batch (RECOMMENDED)
 **Batch processing for cost-effective AI analysis (50% cheaper than individual processing).**
 
 ```bash
-uv run github-analysis batch [COMMAND] [OPTIONS]
+uv run gh-analysis batch [COMMAND] [OPTIONS]
 ```
 
 #### submit
 Submit a batch processing job for multiple issues.
 
 ```bash
-uv run github-analysis batch submit product-labeling [OPTIONS]
+uv run gh-analysis batch submit product-labeling [OPTIONS]
 ```
 
 **Options:**
@@ -77,41 +77,41 @@ uv run github-analysis batch submit product-labeling [OPTIONS]
 **Examples:**
 ```bash
 # Batch process all collected issues for an organization (RECOMMENDED)
-uv run github-analysis batch submit product-labeling --org myorg
+uv run gh-analysis batch submit product-labeling --org myorg
 
 # Batch process all issues for a specific repository
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo
 
 # Batch process with specific model
-uv run github-analysis batch submit product-labeling --org myorg --model openai:gpt-4o-mini
+uv run gh-analysis batch submit product-labeling --org myorg --model openai:gpt-4o-mini
 ```
 
 #### status
 Check the status of a batch processing job.
 
 ```bash
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch status <job-id>
 ```
 
 #### collect
 Collect and process results from a completed batch job.
 
 ```bash
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 ```
 
 #### list
 List all batch processing jobs.
 
 ```bash
-uv run github-analysis batch list
+uv run gh-analysis batch list
 ```
 
 #### cancel
 Cancel an active batch processing job.
 
 ```bash
-uv run github-analysis batch cancel <job-id>
+uv run gh-analysis batch cancel <job-id>
 ```
 
 **Notes:**
@@ -123,8 +123,8 @@ uv run github-analysis batch cancel <job-id>
 Remove a batch job record and associated files.
 
 ```bash
-uv run github-analysis batch remove <job-id>
-uv run github-analysis batch remove <job-id> --force
+uv run gh-analysis batch remove <job-id>
+uv run gh-analysis batch remove <job-id> --force
 ```
 
 **Options:**
@@ -138,33 +138,33 @@ uv run github-analysis batch remove <job-id> --force
 **Typical Batch Workflow:**
 ```bash
 # 1. Collect issues
-uv run github-analysis collect --org myorg --limit 30
+uv run gh-analysis collect --org myorg --limit 30
 
 # 2. Submit batch job
-uv run github-analysis batch submit product-labeling --org myorg
+uv run gh-analysis batch submit product-labeling --org myorg
 
 # 3. Check status periodically (shows real-time progress)
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch status <job-id>
 
 # 4. Collect results when completed
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 
 # 5. Update labels with dry run first
-uv run github-analysis update-labels --org myorg --dry-run
+uv run gh-analysis update-labels --org myorg --dry-run
 ```
 
 ### process
 **Individual AI processing commands (use only for single issues or testing).**
 
 ```bash
-uv run github-analysis process [COMMAND] [OPTIONS]
+uv run gh-analysis process [COMMAND] [OPTIONS]
 ```
 
 #### show-settings
 Display available model settings that can be configured.
 
 ```bash
-uv run github-analysis process show-settings
+uv run gh-analysis process show-settings
 ```
 
 Shows common settings like:
@@ -179,7 +179,7 @@ Shows common settings like:
 Analyze GitHub issues for product labeling recommendations with optional image processing.
 
 ```bash
-uv run github-analysis process product-labeling [OPTIONS]
+uv run gh-analysis process product-labeling [OPTIONS]
 ```
 
 **Options:**
@@ -195,31 +195,31 @@ uv run github-analysis process product-labeling [OPTIONS]
 **Examples:**
 ```bash
 # Show available model settings
-uv run github-analysis process show-settings
+uv run gh-analysis process show-settings
 
 # Process all collected issues for a repository
-uv run github-analysis process product-labeling --org myorg --repo myrepo
+uv run gh-analysis process product-labeling --org myorg --repo myrepo
 
 # Process a specific issue with custom model
-uv run github-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 --model openai:o4-mini
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 --model openai:o4-mini
 
 # Process with custom model settings
-uv run github-analysis process product-labeling --org myorg --repo myrepo \
+uv run gh-analysis process product-labeling --org myorg --repo myrepo \
   --model anthropic:claude-3-5-sonnet \
   --setting temperature=0.5 \
   --setting reasoning_effort=high
 
 # Process with multiple settings
-uv run github-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 \
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 \
   --model openai:o4-mini \
   --setting reasoning_effort=medium \
   --setting max_tokens=2000
 
 # Dry run to see what would be processed
-uv run github-analysis process product-labeling --org myorg --repo myrepo --dry-run
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --dry-run
 
 # Force reprocessing of already reviewed items
-uv run github-analysis process product-labeling --org myorg --repo myrepo --reprocess
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --reprocess
 ```
 
 **Note on Model Settings:**
@@ -232,7 +232,7 @@ uv run github-analysis process product-labeling --org myorg --repo myrepo --repr
 Update GitHub issue labels based on AI recommendations from product-labeling analysis.
 
 ```bash
-uv run github-analysis update-labels [OPTIONS]
+uv run gh-analysis update-labels [OPTIONS]
 ```
 
 **Required Setup:**
@@ -252,36 +252,36 @@ uv run github-analysis update-labels [OPTIONS]
 - `--data-dir TEXT`: Data directory path (defaults to ./data)
 
 **Recommended Workflow (Batch Processing):**
-1. Collect issues: `uv run github-analysis collect --org myorg --limit 30`
-2. Submit batch job: `uv run github-analysis batch submit product-labeling --org myorg`
-3. Check status: `uv run github-analysis batch status <job-id>`
-4. Collect results: `uv run github-analysis batch collect <job-id>`
-5. Update labels: `uv run github-analysis update-labels --org myorg --dry-run`
+1. Collect issues: `uv run gh-analysis collect --org myorg --limit 30`
+2. Submit batch job: `uv run gh-analysis batch submit product-labeling --org myorg`
+3. Check status: `uv run gh-analysis batch status <job-id>`
+4. Collect results: `uv run gh-analysis batch collect <job-id>`
+5. Update labels: `uv run gh-analysis update-labels --org myorg --dry-run`
 
 **Alternative Workflow (Individual Processing - for single issues only):**
-1. Collect single issue: `uv run github-analysis collect --org myorg --repo myrepo --issue-number 123`
-2. Process individual issue: `uv run github-analysis process product-labeling --org myorg --repo myrepo --issue-number 123`
-3. Update labels: `uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run`
+1. Collect single issue: `uv run gh-analysis collect --org myorg --repo myrepo --issue-number 123`
+2. Process individual issue: `uv run gh-analysis process product-labeling --org myorg --repo myrepo --issue-number 123`
+3. Update labels: `uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run`
 
 **Examples:**
 ```bash
 # Preview changes for a specific issue (safe to run)
-uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
+uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
 
 # Update all issues in a repository with high confidence threshold
-uv run github-analysis update-labels --org myorg --repo myrepo --min-confidence 0.9
+uv run gh-analysis update-labels --org myorg --repo myrepo --min-confidence 0.9
 
 # Update specific issue with custom confidence threshold
-uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123 --min-confidence 0.75
+uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123 --min-confidence 0.75
 
 # Apply all changes regardless of confidence (use with caution)
-uv run github-analysis update-labels --org myorg --repo myrepo --force
+uv run gh-analysis update-labels --org myorg --repo myrepo --force
 
 # Update labels without posting explanatory comments
-uv run github-analysis update-labels --org myorg --repo myrepo --skip-comments
+uv run gh-analysis update-labels --org myorg --repo myrepo --skip-comments
 
 # Process up to 5 issues with 1 second delay between API calls
-uv run github-analysis update-labels --org myorg --repo myrepo --max-issues 5 --delay 1.0
+uv run gh-analysis update-labels --org myorg --repo myrepo --max-issues 5 --delay 1.0
 ```
 
 **Safety Features:**
@@ -304,7 +304,7 @@ uv run github-analysis update-labels --org myorg --repo myrepo --max-issues 5 --
 Show storage status and statistics.
 
 ```bash
-uv run github-analysis status
+uv run gh-analysis status
 ```
 
 Displays:
@@ -316,7 +316,7 @@ Displays:
 Show version information.
 
 ```bash
-uv run github-analysis version
+uv run gh-analysis version
 ```
 
 ## Model Configuration
@@ -332,16 +332,16 @@ The simplified AI architecture uses a generic `--setting` flag for all model con
 
 ```bash
 # OpenAI reasoning models
-uv run github-analysis process product-labeling --model openai:o4-mini \
+uv run gh-analysis process product-labeling --model openai:o4-mini \
   --setting reasoning_effort=medium
 
 # Anthropic models with thinking
-uv run github-analysis process product-labeling --model anthropic:claude-3-5-sonnet-latest \
+uv run gh-analysis process product-labeling --model anthropic:claude-3-5-sonnet-latest \
   --setting reasoning_effort=high \
   --setting temperature=0.5
 
 # Multiple settings
-uv run github-analysis process product-labeling --model openai:gpt-4o \
+uv run gh-analysis process product-labeling --model openai:gpt-4o \
   --setting temperature=0.7 \
   --setting max_tokens=2000 \
   --setting top_p=0.9

--- a/docs/cli-standards.md
+++ b/docs/cli-standards.md
@@ -138,28 +138,28 @@ These letters are available for future use:
 ### collect Command
 ```bash
 # Using standardized options
-uv run github-analysis collect -o myorg -r myrepo -i 123 -l bug,enhancement
+uv run gh-analysis collect -o myorg -r myrepo -i 123 -l bug,enhancement
 
 # Full form equivalent
-uv run github-analysis collect --org myorg --repo myrepo --issue-number 123 --labels bug --labels enhancement
+uv run gh-analysis collect --org myorg --repo myrepo --issue-number 123 --labels bug --labels enhancement
 ```
 
 ### update-labels Command  
 ```bash
 # Using new shorthand options (added in CLI normalization)
-uv run github-analysis update-labels -o myorg -r myrepo -i 123 -d
+uv run gh-analysis update-labels -o myorg -r myrepo -i 123 -d
 
 # Full form equivalent
-uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
+uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
 ```
 
 ### batch Command
 ```bash
 # Batch processing with shorthand
-uv run github-analysis batch submit product-labeling -o myorg -r myrepo -d
+uv run gh-analysis batch submit product-labeling -o myorg -r myrepo -d
 
 # Full form equivalent  
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo --dry-run
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo --dry-run
 ```
 
 ## Testing Standards
@@ -190,15 +190,15 @@ Test that shorthand options work correctly:
 
 ```bash
 # Test help shorthand on all commands
-uv run github-analysis collect -h
-uv run github-analysis batch -h
-uv run github-analysis process -h
-uv run github-analysis update-labels -h
+uv run gh-analysis collect -h
+uv run gh-analysis batch -h
+uv run gh-analysis process -h
+uv run gh-analysis update-labels -h
 
 # Test specific shorthand options
-uv run github-analysis collect -o test-org --dry-run
-uv run github-analysis update-labels -o test-org -r test-repo -d
-uv run github-analysis batch submit product-labeling -o test-org -d
+uv run gh-analysis collect -o test-org --dry-run
+uv run gh-analysis update-labels -o test-org -r test-repo -d
+uv run gh-analysis batch submit product-labeling -o test-org -d
 ```
 
 ## Migration Notes

--- a/docs/data-schemas.md
+++ b/docs/data-schemas.md
@@ -184,7 +184,7 @@ Implement the core functionality to collect GitHub issues using the advanced sea
 [Agent documents progress, decisions, and validation steps here]
 
 **Validation:**
-- Run `uv run github-analysis collect --org test --repo test`
+- Run `uv run gh-analysis collect --org test --repo test`
 - Verify JSON files created in `data/issues/`
 - Check rate limiting works with large result sets
 - Ensure all tests pass

--- a/docs/label-updates-guide.md
+++ b/docs/label-updates-guide.md
@@ -46,17 +46,17 @@ data/
 
 ### Step 1: Collect Issues
 ```bash
-uv run github-analysis collect --org myorg --repo myrepo --limit 10
+uv run gh-analysis collect --org myorg --repo myrepo --limit 10
 ```
 
 ### Step 2: Run AI Analysis  
 ```bash
-uv run github-analysis process product-labeling --org myorg --repo myrepo
+uv run gh-analysis process product-labeling --org myorg --repo myrepo
 ```
 
 ### Step 3: Preview Changes (Recommended)
 ```bash
-uv run github-analysis update-labels --org myorg --repo myrepo --dry-run
+uv run gh-analysis update-labels --org myorg --repo myrepo --dry-run
 ```
 
 The dry run shows you exactly what changes will be made, including:
@@ -66,7 +66,7 @@ The dry run shows you exactly what changes will be made, including:
 
 ### Step 4: Apply Changes
 ```bash
-uv run github-analysis update-labels --org myorg --repo myrepo
+uv run gh-analysis update-labels --org myorg --repo myrepo
 ```
 
 ## Usage Examples
@@ -74,31 +74,31 @@ uv run github-analysis update-labels --org myorg --repo myrepo
 ### Single Issue Update
 ```bash
 # Preview changes for one issue
-uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
+uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123 --dry-run
 
 # Apply changes to one issue
-uv run github-analysis update-labels --org myorg --repo myrepo --issue-number 123
+uv run gh-analysis update-labels --org myorg --repo myrepo --issue-number 123
 ```
 
 ### Batch Processing with Safety
 ```bash
 # High confidence only (90%+)
-uv run github-analysis update-labels --org myorg --repo myrepo --min-confidence 0.9
+uv run gh-analysis update-labels --org myorg --repo myrepo --min-confidence 0.9
 
 # Limit to 5 issues with delay between API calls
-uv run github-analysis update-labels --org myorg --repo myrepo --max-issues 5 --delay 2.0
+uv run gh-analysis update-labels --org myorg --repo myrepo --max-issues 5 --delay 2.0
 
 # Skip posting explanatory comments
-uv run github-analysis update-labels --org myorg --repo myrepo --skip-comments
+uv run gh-analysis update-labels --org myorg --repo myrepo --skip-comments
 ```
 
 ### Advanced Options
 ```bash
 # Force apply all changes (use with extreme caution)
-uv run github-analysis update-labels --org myorg --repo myrepo --force
+uv run gh-analysis update-labels --org myorg --repo myrepo --force
 
 # Custom data directory
-uv run github-analysis update-labels --org myorg --repo myrepo --data-dir /path/to/data
+uv run gh-analysis update-labels --org myorg --repo myrepo --data-dir /path/to/data
 ```
 
 ## Understanding the Output
@@ -279,7 +279,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run github-analysis update-labels \
+          uv run gh-analysis update-labels \
             --org ${{ github.repository_owner }} \
             --repo ${{ github.event.repository.name }} \
             --min-confidence 0.9 \

--- a/docs/recommendation-cli-reference.md
+++ b/docs/recommendation-cli-reference.md
@@ -5,7 +5,7 @@ This document provides detailed information about all recommendation management 
 ## Commands Overview
 
 ```bash
-uv run github-analysis recommendations <command> [options]
+uv run gh-analysis recommendations <command> [options]
 ```
 
 Available commands:
@@ -19,7 +19,7 @@ Available commands:
 Scans the results directory for AI analysis files and creates/updates recommendation metadata.
 
 ```bash
-uv run github-analysis recommendations discover [OPTIONS]
+uv run gh-analysis recommendations discover [OPTIONS]
 ```
 
 ### Options:
@@ -35,10 +35,10 @@ uv run github-analysis recommendations discover [OPTIONS]
 
 ```bash
 # Discover new recommendations
-uv run github-analysis recommendations discover
+uv run gh-analysis recommendations discover
 
 # Force refresh all recommendations (e.g., after reprocessing)
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 ```
 
 ## Command: `list`
@@ -46,7 +46,7 @@ uv run github-analysis recommendations discover --force-refresh
 Lists recommendations with various filtering options.
 
 ```bash
-uv run github-analysis recommendations list [OPTIONS]
+uv run gh-analysis recommendations list [OPTIONS]
 ```
 
 ### Options:
@@ -70,19 +70,19 @@ uv run github-analysis recommendations list [OPTIONS]
 
 ```bash
 # List all pending recommendations (excluding NO_CHANGE_NEEDED)
-uv run github-analysis recommendations list
+uv run gh-analysis recommendations list
 
 # List high-confidence pending recommendations for KOTS
-uv run github-analysis recommendations list --status pending --product kots --min-confidence 0.9
+uv run gh-analysis recommendations list --status pending --product kots --min-confidence 0.9
 
 # Show all recommendations including those needing no changes
-uv run github-analysis recommendations list --include-no-change
+uv run gh-analysis recommendations list --include-no-change
 
 # Export recommendations as JSON
-uv run github-analysis recommendations list --format json > recommendations.json
+uv run gh-analysis recommendations list --format json > recommendations.json
 
 # List recommendations for a specific repository
-uv run github-analysis recommendations list --org myorg --repo myrepo
+uv run gh-analysis recommendations list --org myorg --repo myrepo
 ```
 
 ## Command: `summary`
@@ -90,7 +90,7 @@ uv run github-analysis recommendations list --org myorg --repo myrepo
 Shows a dashboard with recommendation statistics.
 
 ```bash
-uv run github-analysis recommendations summary [OPTIONS]
+uv run gh-analysis recommendations summary [OPTIONS]
 ```
 
 ### Options:
@@ -110,7 +110,7 @@ uv run github-analysis recommendations summary [OPTIONS]
 Starts an interactive review session for recommendations.
 
 ```bash
-uv run github-analysis recommendations review-session [OPTIONS]
+uv run gh-analysis recommendations review-session [OPTIONS]
 ```
 
 ### Options:
@@ -136,13 +136,13 @@ uv run github-analysis recommendations review-session [OPTIONS]
 
 ```bash
 # Review all pending recommendations
-uv run github-analysis recommendations review-session
+uv run gh-analysis recommendations review-session
 
 # Review only high-confidence KOTS recommendations
-uv run github-analysis recommendations review-session --product kots --min-confidence 0.9
+uv run gh-analysis recommendations review-session --product kots --min-confidence 0.9
 
 # Review pending and needs_modification items for specific repo
-uv run github-analysis recommendations review-session --org myorg --repo myrepo --status pending --status needs_modification
+uv run gh-analysis recommendations review-session --org myorg --repo myrepo --status pending --status needs_modification
 ```
 
 ## Status Lifecycle
@@ -162,10 +162,10 @@ When using the `--reprocess` flag with AI processing:
 
 ```bash
 # Reprocess all issues (including NO_CHANGE_NEEDED)
-uv run github-analysis process product-labeling --org myorg --repo myrepo --reprocess
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --reprocess
 
 # Then re-discover to update statuses
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 ```
 
 This workflow ensures that:

--- a/docs/recommendation-workflow.md
+++ b/docs/recommendation-workflow.md
@@ -30,10 +30,10 @@ Scan for new AI analysis results and create trackable recommendation metadata:
 
 ```bash
 # Discover all new recommendations
-uv run github-analysis recommendations discover
+uv run gh-analysis recommendations discover
 
 # Force refresh existing recommendations
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 ```
 
 This command:
@@ -47,7 +47,7 @@ This command:
 Get a dashboard view of all recommendations:
 
 ```bash
-uv run github-analysis recommendations summary
+uv run gh-analysis recommendations summary
 ```
 
 Shows statistics including:
@@ -63,31 +63,31 @@ View recommendations with detailed filtering:
 
 ```bash
 # List all recommendations (default: table format)
-uv run github-analysis recommendations list
+uv run gh-analysis recommendations list
 
 # Filter by organization
-uv run github-analysis recommendations list --org myorg
+uv run gh-analysis recommendations list --org myorg
 
 # Filter by repository
-uv run github-analysis recommendations list --org myorg --repo myrepo
+uv run gh-analysis recommendations list --org myorg --repo myrepo
 
 # Filter by status
-uv run github-analysis recommendations list --status pending --status approved
+uv run gh-analysis recommendations list --status pending --status approved
 
 # Filter by confidence level
-uv run github-analysis recommendations list --min-confidence 0.8
+uv run gh-analysis recommendations list --min-confidence 0.8
 
 # Filter by confidence tier
-uv run github-analysis recommendations list --confidence-tier high --confidence-tier medium
+uv run gh-analysis recommendations list --confidence-tier high --confidence-tier medium
 
 # Filter by product
-uv run github-analysis recommendations list --product kots --product vendor
+uv run gh-analysis recommendations list --product kots --product vendor
 
 # Limit results
-uv run github-analysis recommendations list --limit 10
+uv run gh-analysis recommendations list --limit 10
 
 # Output as JSON
-uv run github-analysis recommendations list --format json
+uv run gh-analysis recommendations list --format json
 ```
 
 ### Interactive Review Session
@@ -96,13 +96,13 @@ Start an interactive review session to process recommendations:
 
 ```bash
 # Review all pending recommendations
-uv run github-analysis recommendations review-session
+uv run gh-analysis recommendations review-session
 
 # Review with filters
-uv run github-analysis recommendations review-session --org myorg --min-confidence 0.8
+uv run gh-analysis recommendations review-session --org myorg --min-confidence 0.8
 
 # Review specific product recommendations
-uv run github-analysis recommendations review-session --product kots
+uv run gh-analysis recommendations review-session --product kots
 ```
 
 During the review session:
@@ -202,10 +202,10 @@ Use the `--reprocess` flag to override the default behavior:
 
 ```bash
 # Individual processing with reprocess
-uv run github-analysis process product-labeling --org myorg --repo myrepo --reprocess
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --reprocess
 
 # Batch processing with reprocess
-uv run github-analysis batch submit product-labeling --org myorg --reprocess
+uv run gh-analysis batch submit product-labeling --org myorg --reprocess
 ```
 
 This will reprocess ALL issues regardless of their recommendation status.
@@ -245,7 +245,7 @@ ls -la data/recommendation_status/
 cat data/recommendation_status/myorg_myrepo_issue_123_status.json | jq
 
 # Count recommendations by status
-uv run github-analysis recommendations list --format json | \
+uv run gh-analysis recommendations list --format json | \
   jq 'group_by(.status) | map({status: .[0].status, count: length})'
 ```
 
@@ -255,17 +255,17 @@ uv run github-analysis recommendations list --format json | \
 
 1. **Start with high confidence**: Review high-confidence recommendations first
    ```bash
-   uv run github-analysis recommendations review-session --min-confidence 0.9
+   uv run gh-analysis recommendations review-session --min-confidence 0.9
    ```
 
 2. **Focus by product**: Review one product at a time for context
    ```bash
-   uv run github-analysis recommendations review-session --product kots
+   uv run gh-analysis recommendations review-session --product kots
    ```
 
 3. **Batch similar issues**: Review related repositories together
    ```bash
-   uv run github-analysis recommendations review-session --org myorg --repo myrepo
+   uv run gh-analysis recommendations review-session --org myorg --repo myrepo
    ```
 
 ### Review Notes
@@ -279,8 +279,8 @@ Add meaningful review notes to track decisions:
 
 1. Run discovery after each AI batch:
    ```bash
-   uv run github-analysis batch collect <job-id>
-   uv run github-analysis recommendations discover
+   uv run gh-analysis batch collect <job-id>
+   uv run gh-analysis recommendations discover
    ```
 
 2. Schedule regular review sessions
@@ -292,17 +292,17 @@ The recommendation system integrates seamlessly with existing commands:
 
 ```bash
 # 1. Collect issues as normal
-uv run github-analysis collect --org myorg --repo myrepo
+uv run gh-analysis collect --org myorg --repo myrepo
 
 # 2. Process with AI (automatically respects review status)
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo
 
 # 3. Discover and review recommendations
-uv run github-analysis recommendations discover
-uv run github-analysis recommendations review-session
+uv run gh-analysis recommendations discover
+uv run gh-analysis recommendations review-session
 
 # 4. Apply approved changes (Phase 2 feature)
-# uv run github-analysis update-labels --approved-only
+# uv run gh-analysis update-labels --approved-only
 ```
 
 ## Advanced Usage
@@ -313,14 +313,14 @@ Complex filtering for specific scenarios:
 
 ```bash
 # High-confidence KOTS issues from last week
-uv run github-analysis recommendations list \
+uv run gh-analysis recommendations list \
   --product kots \
   --min-confidence 0.85 \
   --status pending \
   --format json | jq '.[] | select(.status_updated_at > "2024-01-15")'
 
 # Rejected recommendations needing re-evaluation
-uv run github-analysis recommendations list \
+uv run gh-analysis recommendations list \
   --status rejected \
   --search-text "database" \
   --format table

--- a/docs/reprocessing-workflow.md
+++ b/docs/reprocessing-workflow.md
@@ -8,13 +8,13 @@ This approach reprocesses all issues regardless of their current status:
 
 ```bash
 # 1. Reprocess all issues with the --reprocess flag
-uv run github-analysis process product-labeling --org myorg --repo myrepo --reprocess
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --reprocess
 
 # 2. Re-discover recommendations to update statuses
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 
 # 3. Review the updated recommendations
-uv run github-analysis recommendations list
+uv run gh-analysis recommendations list
 ```
 
 ## Option 2: Batch Reprocessing (Cost-Effective)
@@ -23,16 +23,16 @@ For large repositories, use batch processing:
 
 ```bash
 # 1. Submit batch job with reprocess flag
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo --reprocess
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo --reprocess
 
 # 2. Check batch status
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch status <job-id>
 
 # 3. Collect results when complete
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 
 # 4. Re-discover recommendations
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 ```
 
 ## Option 3: Selective Reprocessing
@@ -41,13 +41,13 @@ To reprocess only specific issues:
 
 ```bash
 # 1. List all recommendations including NO_CHANGE_NEEDED
-uv run github-analysis recommendations list --include-no-change
+uv run gh-analysis recommendations list --include-no-change
 
 # 2. Reprocess specific issues
-uv run github-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 --reprocess
+uv run gh-analysis process product-labeling --org myorg --repo myrepo --issue-number 123 --reprocess
 
 # 3. Re-discover for that issue
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 ```
 
 ## Understanding Status Transitions
@@ -68,18 +68,18 @@ uv run github-analysis recommendations discover --force-refresh
 
 ```bash
 # See current state
-uv run github-analysis recommendations summary
+uv run gh-analysis recommendations summary
 
 # Reprocess everything
-uv run github-analysis batch submit product-labeling --org myorg --reprocess
+uv run gh-analysis batch submit product-labeling --org myorg --reprocess
 
 # Wait for completion...
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 
 # Update all statuses
-uv run github-analysis recommendations discover --force-refresh
+uv run gh-analysis recommendations discover --force-refresh
 
 # See what changed
-uv run github-analysis recommendations summary
-uv run github-analysis recommendations list  # Shows only items needing changes
+uv run gh-analysis recommendations summary
+uv run gh-analysis recommendations list  # Shows only items needing changes
 ```

--- a/gh_analysis
+++ b/gh_analysis
@@ -1,0 +1,1 @@
+github_issue_analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "github-issue-analysis"
+name = "gh-analysis"
 version = "0.2.0"
 description = "GitHub issue collection and AI-powered analysis"
 requires-python = ">=3.13"
@@ -35,7 +35,7 @@ export = [
 ]
 
 [project.scripts]
-github-analysis = "github_issue_analysis.cli.main:app"
+gh-analysis = "github_issue_analysis.cli.main:app"
 
 [tool.hatchling.build.targets.wheel]
 packages = ["github_issue_analysis"]

--- a/tasks/ai-batch-processing-phase2-duckdb-selection.md
+++ b/tasks/ai-batch-processing-phase2-duckdb-selection.md
@@ -31,19 +31,19 @@ Extend batch processing with SQL-powered issue selection using DuckDB. Adds inte
 ## New Operations
 ```bash
 # Batch process using SQL selection
-uv run github-analysis batch submit product-labeling --sql "SELECT * FROM issues WHERE state='open'"
+uv run gh-analysis batch submit product-labeling --sql "SELECT * FROM issues WHERE state='open'"
 
 # Batch process issues missing analysis
-uv run github-analysis batch submit product-labeling --missing-analysis
+uv run gh-analysis batch submit product-labeling --missing-analysis
 
 # Batch process specific repository
-uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
+uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
 
 # Show batch job history from database
-uv run github-analysis batch history
+uv run gh-analysis batch history
 
 # Show batch job details
-uv run github-analysis batch details <job-id>
+uv run gh-analysis batch details <job-id>
 ```
 
 ## New Functionality
@@ -146,34 +146,34 @@ class BatchManager:
 ### **Setup and Database Integration**
 ```bash
 # 1. Ensure DuckDB Phase 1 is working
-uv run github-analysis status  # Should show database enabled
+uv run gh-analysis status  # Should show database enabled
 
 # 2. Verify database has issues
-uv run github-analysis query sql "SELECT COUNT(*) FROM issues"
+uv run gh-analysis query sql "SELECT COUNT(*) FROM issues"
 
 # 3. Test SQL-based batch selection
-uv run github-analysis batch submit product-labeling --sql "SELECT * FROM issues WHERE state='open' LIMIT 5"
+uv run gh-analysis batch submit product-labeling --sql "SELECT * FROM issues WHERE state='open' LIMIT 5"
 ```
 
 ### **Batch Job Tracking**
 ```bash
 # 4. Check batch job was stored in database
-uv run github-analysis batch history
+uv run gh-analysis batch history
 
 # 5. Test missing analysis selection
-uv run github-analysis batch submit product-labeling --missing-analysis
+uv run gh-analysis batch submit product-labeling --missing-analysis
 
 # 6. Verify batch job details
-uv run github-analysis batch details <job-id>
+uv run gh-analysis batch details <job-id>
 ```
 
 ### **Database Queries**
 ```bash
 # 7. Query batch jobs directly
-uv run github-analysis query sql "SELECT * FROM batch_jobs ORDER BY created_at DESC"
+uv run gh-analysis query sql "SELECT * FROM batch_jobs ORDER BY created_at DESC"
 
 # 8. Check batch items tracking
-uv run github-analysis query sql "SELECT COUNT(*) FROM batch_items"
+uv run gh-analysis query sql "SELECT COUNT(*) FROM batch_items"
 ```
 
 ### **Integration Testing**
@@ -182,7 +182,7 @@ uv run github-analysis query sql "SELECT COUNT(*) FROM batch_items"
 # Run same batch twice, verify second run skips already processed issues
 
 # 10. Test error handling with invalid SQL
-uv run github-analysis batch submit product-labeling --sql "INVALID SQL"
+uv run gh-analysis batch submit product-labeling --sql "INVALID SQL"
 ```
 
 ## Success Criteria

--- a/tasks/ai-batch-processing-phase3-pipeline-integration.md
+++ b/tasks/ai-batch-processing-phase3-pipeline-integration.md
@@ -27,15 +27,15 @@ Add batch execution mode to existing DuckDB Phase 2 pipeline commands. Allows al
 ## New Operations
 ```bash
 # Existing pipeline commands with --batch-mode added
-uv run github-analysis process-query missing product-labeling --batch-mode
-uv run github-analysis process-query reprocess product-labeling --threshold 0.7 --batch-mode
-uv run github-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state='open'" --batch-mode
+uv run gh-analysis process-query missing product-labeling --batch-mode
+uv run gh-analysis process-query reprocess product-labeling --threshold 0.7 --batch-mode
+uv run gh-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state='open'" --batch-mode
 
 # Repository and filtering with batch mode
-uv run github-analysis process-query missing product-labeling --org replicated --repo kots --batch-mode
+uv run gh-analysis process-query missing product-labeling --org replicated --repo kots --batch-mode
 
 # Monitor batch jobs from pipeline
-uv run github-analysis process-query batch-status
+uv run gh-analysis process-query batch-status
 ```
 
 ## New Functionality
@@ -230,38 +230,38 @@ def batch_status():
 ### **Setup and Prerequisites**
 ```bash
 # 1. Ensure DuckDB Phase 2 is working
-uv run github-analysis process-query missing product-labeling --limit 1
+uv run gh-analysis process-query missing product-labeling --limit 1
 
 # 2. Ensure batch processing Phase 1 & 2 are working
-uv run github-analysis batch history
+uv run gh-analysis batch history
 ```
 
 ### **Pipeline Batch Mode Testing**
 ```bash
 # 3. Test missing analysis in batch mode
-uv run github-analysis process-query missing product-labeling --batch-mode --limit 5
+uv run gh-analysis process-query missing product-labeling --batch-mode --limit 5
 
 # 4. Test reprocessing in batch mode
-uv run github-analysis process-query reprocess product-labeling --threshold 0.8 --batch-mode --limit 3
+uv run gh-analysis process-query reprocess product-labeling --threshold 0.8 --batch-mode --limit 3
 
 # 5. Test custom query in batch mode
-uv run github-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state='closed'" --batch-mode --limit 2
+uv run gh-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state='closed'" --batch-mode --limit 2
 ```
 
 ### **Batch Monitoring**
 ```bash
 # 6. Check batch job status
-uv run github-analysis process-query batch-status
+uv run gh-analysis process-query batch-status
 
 # 7. Verify batch jobs are tracked in database
-uv run github-analysis query sql "SELECT job_id, processor, status FROM batch_jobs ORDER BY created_at DESC LIMIT 5"
+uv run gh-analysis query sql "SELECT job_id, processor, status FROM batch_jobs ORDER BY created_at DESC LIMIT 5"
 ```
 
 ### **Integration Testing**
 ```bash
 # 8. Test same command in real-time vs batch mode
-uv run github-analysis process-query missing product-labeling --limit 2  # Real-time
-uv run github-analysis process-query missing product-labeling --limit 2 --batch-mode  # Batch
+uv run gh-analysis process-query missing product-labeling --limit 2  # Real-time
+uv run gh-analysis process-query missing product-labeling --limit 2 --batch-mode  # Batch
 
 # 9. Verify results end up in same location
 ls data/results/*_product-labeling.json
@@ -270,10 +270,10 @@ ls data/results/*_product-labeling.json
 ### **Error Handling**
 ```bash
 # 10. Test batch mode with invalid processor
-uv run github-analysis process-query missing invalid-processor --batch-mode
+uv run gh-analysis process-query missing invalid-processor --batch-mode
 
 # 11. Test batch status with no jobs
-uv run github-analysis process-query batch-status
+uv run gh-analysis process-query batch-status
 ```
 
 ## Success Criteria

--- a/tasks/ai-simplification-phase3-batch.md
+++ b/tasks/ai-simplification-phase3-batch.md
@@ -84,7 +84,7 @@ batch_config = {
 ### Manual Verification Commands
 ```bash
 # Submit batch job with new options
-uv run github-analysis batch submit product-labeling \
+uv run gh-analysis batch submit product-labeling \
     --org test --repo test \
     --model anthropic:claude-3-haiku-20241022 \
     --thinking-effort medium \
@@ -93,8 +93,8 @@ uv run github-analysis batch submit product-labeling \
     --dry-run
 
 # Check batch job management
-uv run github-analysis batch list
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch list
+uv run gh-analysis batch status <job-id>
 
 # Quality checks
 uv run pytest tests/test_cli/test_batch.py -v

--- a/tasks/ai-simplification-phase5-documentation.md
+++ b/tasks/ai-simplification-phase5-documentation.md
@@ -61,14 +61,14 @@ async def product_labeling(
     
     Examples:
         # Basic usage
-        github-analysis process product-labeling --org myorg --repo myrepo
+        gh-analysis process product-labeling --org myorg --repo myrepo
         
         # With specific model and thinking
-        github-analysis process product-labeling --org myorg --repo myrepo \\
+        gh-analysis process product-labeling --org myorg --repo myrepo \\
             --model openai:o1-mini --thinking-effort high
         
         # Process single issue
-        github-analysis process product-labeling --org myorg --repo myrepo \\
+        gh-analysis process product-labeling --org myorg --repo myrepo \\
             --issue-number 123 --dry-run
     """
 ```
@@ -85,15 +85,15 @@ async def product_labeling(
 uv run pytest -v --cov=src/github_analysis --cov-report=term-missing
 
 # CLI help quality verification
-uv run github-analysis --help
-uv run github-analysis process --help
-uv run github-analysis process product-labeling --help
-uv run github-analysis batch --help
-uv run github-analysis batch submit --help
+uv run gh-analysis --help
+uv run gh-analysis process --help
+uv run gh-analysis process product-labeling --help
+uv run gh-analysis batch --help
+uv run gh-analysis batch submit --help
 
 # End-to-end workflow testing
-uv run github-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
-uv run github-analysis batch submit product-labeling --org test --repo test --dry-run
+uv run gh-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
+uv run gh-analysis batch submit product-labeling --org test --repo test --dry-run
 ```
 
 ### Success Metrics Verification
@@ -108,11 +108,11 @@ uv run github-analysis batch submit product-labeling --org test --repo test --dr
 uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest -v
 
 # Help text verification
-uv run github-analysis process product-labeling --help | grep -A 10 "AI Configuration"
+uv run gh-analysis process product-labeling --help | grep -A 10 "AI Configuration"
 
 # Final integration tests
-uv run github-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
-uv run github-analysis batch submit product-labeling --org test --repo test --dry-run
+uv run gh-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
+uv run gh-analysis batch submit product-labeling --org test --repo test --dry-run
 
 # Line count verification
 git diff --stat HEAD~5  # Compare to start of project

--- a/tasks/archive/ai-batch-processing-phase1-basic.md
+++ b/tasks/archive/ai-batch-processing-phase1-basic.md
@@ -27,22 +27,22 @@ Implement basic OpenAI Batch API integration for cost-effective AI processing. W
 ## New Operations
 ```bash
 # Submit batch job using standard CLI patterns
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo
 
 # Submit batch job for entire organization
-uv run github-analysis batch submit product-labeling --org myorg
+uv run gh-analysis batch submit product-labeling --org myorg
 
 # Submit specific issue to batch processing
-uv run github-analysis batch submit product-labeling --org myorg --repo myrepo --issue-number 123
+uv run gh-analysis batch submit product-labeling --org myorg --repo myrepo --issue-number 123
 
 # Check batch job status
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch status <job-id>
 
 # Collect completed batch results
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 
 # List all batch jobs
-uv run github-analysis batch list
+uv run gh-analysis batch list
 ```
 
 ## New Functionality
@@ -66,7 +66,7 @@ uv run github-analysis batch list
 **Batch Command Implementation:**
 ```bash
 # Follow same patterns as collect/process commands
-uv run github-analysis batch submit product-labeling [STANDARD_FLAGS]
+uv run gh-analysis batch submit product-labeling [STANDARD_FLAGS]
 
 # Where STANDARD_FLAGS match existing commands:
 # --org myorg --repo myrepo          # Repository-specific  
@@ -128,16 +128,16 @@ class OpenAIBatchProvider:
 ### **Setup and Testing**
 ```bash
 # 1. Ensure existing data is available
-uv run github-analysis status
+uv run gh-analysis status
 
 # 2. Test batch submission with standard CLI patterns
-uv run github-analysis batch submit product-labeling --org test-org --repo test-repo
+uv run gh-analysis batch submit product-labeling --org test-org --repo test-repo
 
 # 3. Check job status
-uv run github-analysis batch status <job-id>
+uv run gh-analysis batch status <job-id>
 
 # 4. Collect results when ready
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch collect <job-id>
 
 # 5. Verify results are in correct format
 ls data/results/*_product-labeling.json
@@ -146,10 +146,10 @@ ls data/results/*_product-labeling.json
 ### **Error Handling**
 ```bash
 # 6. Test with nonexistent organization/repository
-uv run github-analysis batch submit product-labeling --org nonexistent-org --repo nonexistent-repo
+uv run gh-analysis batch submit product-labeling --org nonexistent-org --repo nonexistent-repo
 
 # 7. Test with no collected issues
-uv run github-analysis batch submit product-labeling --org empty-org --repo empty-repo
+uv run gh-analysis batch submit product-labeling --org empty-org --repo empty-repo
 ```
 
 ## Success Criteria

--- a/tasks/archive/ai-product-labeling-phase1.md
+++ b/tasks/archive/ai-product-labeling-phase1.md
@@ -255,17 +255,17 @@ Analyze the provided issue and respond with structured recommendations including
 ### Basic Command Structure
 ```bash
 # Process specific issue (primary use case)
-uv run github-analysis process --task product-labeling --issue 71
+uv run gh-analysis process --task product-labeling --issue 71
 
 # Process all collected issues
-uv run github-analysis process --task product-labeling
+uv run gh-analysis process --task product-labeling
 
 # Use different model
-uv run github-analysis process --task product-labeling --issue 71 --model anthropic:claude-3-5-sonnet
+uv run gh-analysis process --task product-labeling --issue 71 --model anthropic:claude-3-5-sonnet
 
 # Environment configuration
 export AI_MODEL=openai:gpt-4o-mini
-uv run github-analysis process --task product-labeling --issue 71
+uv run gh-analysis process --task product-labeling --issue 71
 ```
 
 ### CLI Implementation

--- a/tasks/archive/ai-product-labeling-phase2.md
+++ b/tasks/archive/ai-product-labeling-phase2.md
@@ -427,16 +427,16 @@ def test_load_downloaded_images_disabled():
 
 ```bash
 # Test with images (default)
-uv run github-analysis process --task product-labeling --issue 71
+uv run gh-analysis process --task product-labeling --issue 71
 
 # Test without images for comparison
-uv run github-analysis process --task product-labeling --issue 71 --no-images
+uv run gh-analysis process --task product-labeling --issue 71 --no-images
 
 # Process all issues with image analysis
-uv run github-analysis process --task product-labeling --include-images
+uv run gh-analysis process --task product-labeling --include-images
 
 # Use higher quality model for complex image analysis
-uv run github-analysis process --task product-labeling --issue 71 --model openai:gpt-4o
+uv run gh-analysis process --task product-labeling --issue 71 --model openai:gpt-4o
 ```
 
 ## Expected Improvements

--- a/tasks/archive/ai-simplification-phase2-cli.md
+++ b/tasks/archive/ai-simplification-phase2-cli.md
@@ -82,10 +82,10 @@ model: Annotated[str, Option(
 ### Manual Verification Commands
 ```bash
 # Basic functionality
-uv run github-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
+uv run gh-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
 
 # With new options
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
     --org test --repo test --issue-number 1 \
     --model anthropic:claude-3-haiku-20241022 \
     --thinking-effort high \
@@ -94,7 +94,7 @@ uv run github-analysis process product-labeling \
     --dry-run
 
 # Help text quality
-uv run github-analysis process product-labeling --help
+uv run gh-analysis process product-labeling --help
 
 # Quality checks
 uv run pytest tests/test_cli/test_process.py -v
@@ -224,7 +224,7 @@ uv run pytest tests/test_cli/test_process.py -v
 
 **Help Text Display:**
 ```bash
-uv run github-analysis process product-labeling --help
+uv run gh-analysis process product-labeling --help
 ```
 Output: Displays well-organized rich help panels with Target Selection, AI Configuration, and Processing Options sections, plus comprehensive examples.
 

--- a/tasks/archive/ai-simplification-phase4-cleanup.md
+++ b/tasks/archive/ai-simplification-phase4-cleanup.md
@@ -84,8 +84,8 @@ THINKING_MODELS = {
 uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest -v
 
 # Test core functionality still works
-uv run github-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
-uv run github-analysis batch submit product-labeling --org test --repo test --dry-run
+uv run gh-analysis process product-labeling --org test --repo test --issue-number 1 --dry-run
+uv run gh-analysis batch submit product-labeling --org test --repo test --dry-run
 
 # Verify line count reduction
 git diff --stat HEAD~4  # Compare to before Phase 1

--- a/tasks/archive/batch-cancel-remove-operations.md
+++ b/tasks/archive/batch-cancel-remove-operations.md
@@ -28,7 +28,7 @@ Users need the ability to:
 ## Acceptance Criteria
 
 ### Cancel Functionality
-- [ ] Add `cancel` command to CLI: `uv run github-analysis batch cancel <job-id>`
+- [ ] Add `cancel` command to CLI: `uv run gh-analysis batch cancel <job-id>`
 - [ ] Implement `cancel_batch()` method in OpenAI provider to call DELETE API
 - [ ] Implement `cancel_job()` method in BatchManager 
 - [ ] Handle different job states appropriately:
@@ -39,7 +39,7 @@ Users need the ability to:
 - [ ] Handle API errors gracefully (job already completed, etc.)
 
 ### Remove Functionality  
-- [ ] Add `remove` command to CLI: `uv run github-analysis batch remove <job-id>`
+- [ ] Add `remove` command to CLI: `uv run gh-analysis batch remove <job-id>`
 - [ ] Implement `remove_job()` method in BatchManager
 - [ ] Remove job metadata file from `data/batch/jobs/`
 - [ ] Optionally remove associated input/output files
@@ -88,13 +88,13 @@ Users need the ability to:
 
 ```bash
 # Cancel an active batch job
-uv run github-analysis batch cancel <job-id>
+uv run gh-analysis batch cancel <job-id>
 
 # Remove a batch job record (with confirmation)
-uv run github-analysis batch remove <job-id>
+uv run gh-analysis batch remove <job-id>
 
 # Remove a batch job record (skip confirmation)
-uv run github-analysis batch remove <job-id> --force
+uv run gh-analysis batch remove <job-id> --force
 ```
 
 ### OpenAI Provider Method
@@ -162,24 +162,24 @@ def remove_job(self, job_id: str, force: bool = False) -> bool:
 
 ```bash
 # Setup: Create a test batch job
-uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --dry-run
+uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --dry-run
 
 # Test cancellation
-uv run github-analysis batch cancel <job-id>
-uv run github-analysis batch status <job-id>  # Should show cancelled
+uv run gh-analysis batch cancel <job-id>
+uv run gh-analysis batch status <job-id>  # Should show cancelled
 
 # Test removal with confirmation
-uv run github-analysis batch remove <job-id>
+uv run gh-analysis batch remove <job-id>
 # Should prompt for confirmation
 
 # Test removal with force
-uv run github-analysis batch remove <job-id> --force
+uv run gh-analysis batch remove <job-id> --force
 # Should remove without confirmation
 
 
 # Test error cases
-uv run github-analysis batch cancel nonexistent-job
-uv run github-analysis batch remove nonexistent-job
+uv run gh-analysis batch cancel nonexistent-job
+uv run gh-analysis batch remove nonexistent-job
 
 # Run all tests
 uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest

--- a/tasks/archive/date-range-collection.md
+++ b/tasks/archive/date-range-collection.md
@@ -48,16 +48,16 @@ Enable GitHub issue collection based on date ranges (e.g., "collect all issues i
 **Usage Examples:**
 ```bash
 # Absolute date ranges
-uv run github-analysis collect --org myorg --created-after 2024-01-01 --created-before 2024-06-30
+uv run gh-analysis collect --org myorg --created-after 2024-01-01 --created-before 2024-06-30
 
 # Last 6 months (convenience option)
-uv run github-analysis collect --org myorg --last-months 6
+uv run gh-analysis collect --org myorg --last-months 6
 
 # Combined with existing filters
-uv run github-analysis collect --org myorg --repo myrepo --labels bug --last-weeks 2
+uv run gh-analysis collect --org myorg --repo myrepo --labels bug --last-weeks 2
 
 # Updated date filtering
-uv run github-analysis collect --org myorg --updated-after 2024-01-01
+uv run gh-analysis collect --org myorg --updated-after 2024-01-01
 ```
 
 ### Phase 2: Date Parsing and Validation
@@ -152,43 +152,43 @@ is:issue created:>2024-01-01 updated:<2024-12-31  # Combined filters
 ```bash
 # 1. Test absolute date filtering
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --created-after 2024-01-01 --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --created-after 2024-01-01 --limit 5
 
 # 2. Test relative dates
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --last-months 3 --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --last-months 3 --limit 5
 
 # 3. Test date ranges
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --created-after 2024-01-01 --created-before 2024-06-30 --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --created-after 2024-01-01 --created-before 2024-06-30 --limit 5
 
 # 4. Test updated date filtering
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --updated-after 2024-01-01 --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --updated-after 2024-01-01 --limit 5
 
 # 5. Combine with existing filters
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --labels bug --last-weeks 4 --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --labels bug --last-weeks 4 --limit 5
 ```
 
 ### Edge Case Testing
 ```bash
 # 6. Test invalid date formats
-uv run github-analysis collect --org test --created-after "invalid-date"
+uv run gh-analysis collect --org test --created-after "invalid-date"
 
 # 7. Test invalid date ranges  
-uv run github-analysis collect --org test --created-after 2024-12-31 --created-before 2024-01-01
+uv run gh-analysis collect --org test --created-after 2024-12-31 --created-before 2024-01-01
 
 # 8. Test parameter conflicts
-uv run github-analysis collect --org test --created-after 2024-01-01 --last-months 6
+uv run gh-analysis collect --org test --created-after 2024-01-01 --last-months 6
 
 # 9. Test organization-wide with dates
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --last-months 1 --limit 10
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --last-months 1 --limit 10
 
 # 10. Verify existing functionality unchanged
 # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 ```
 
 ### Quality Assurance
@@ -197,14 +197,14 @@ uv run github-analysis collect --org test --created-after 2024-01-01 --last-mont
 uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest
 
 # 12. Test help documentation
-uv run github-analysis collect --help
+uv run gh-analysis collect --help
 
 # 13. Verify documentation is updated and accurate
 grep -r "created-after\|last-months" docs/
 grep -r "date.*filter" docs/
 
 # 14. Verify storage and results format unchanged
-uv run github-analysis status
+uv run gh-analysis status
 ```
 
 **Dependencies:**

--- a/tasks/archive/fix-thinking-flags-and-remove-o1-mini.md
+++ b/tasks/archive/fix-thinking-flags-and-remove-o1-mini.md
@@ -107,7 +107,7 @@ The new approach should work like this:
 
 **Example 1 - Incompatible Flags:**
 ```
-$ uv run github-analysis process --model openai:gpt-4o --thinking-effort high
+$ uv run gh-analysis process --model openai:gpt-4o --thinking-effort high
 Error: Model 'gpt-4o' does not support thinking-effort flag.
 Compatible flags for this model: [none - standard processing]
 For thinking capabilities, try a model that supports reasoning.
@@ -115,13 +115,13 @@ For thinking capabilities, try a model that supports reasoning.
 
 **Example 2 - Compatible Usage:**
 ```
-$ uv run github-analysis process --model openai:o4-mini --thinking-effort medium
+$ uv run gh-analysis process --model openai:o4-mini --thinking-effort medium
 ✓ Using thinking-capable model with reasoning effort: medium
 ```
 
 **Example 3 - Provider Mismatch:**
 ```
-$ uv run github-analysis process --model anthropic:claude-3-haiku --thinking-effort high  
+$ uv run gh-analysis process --model anthropic:claude-3-haiku --thinking-effort high  
 Error: Model 'claude-3-haiku' does not support OpenAI thinking-effort flag.
 Compatible flags for this model: --thinking-budget (Anthropic reasoning control)
 ```
@@ -159,14 +159,14 @@ Compatible flags for this model: --thinking-budget (Anthropic reasoning control)
 
 1. **Run CLI Commands**:
    ```bash
-   uv run github-analysis process --help
-   uv run github-analysis batch --help
+   uv run gh-analysis process --help
+   uv run gh-analysis batch --help
    ```
    Verify help text uses generic language about compatible models
 
 2. **Test Error Messages**:
    ```bash
-   uv run github-analysis process product-labeling --model openai:gpt-4o --thinking-effort high
+   uv run gh-analysis process product-labeling --model openai:gpt-4o --thinking-effort high
    ```
    Should explain that gpt-4o doesn't support thinking-effort and show compatible flags
 
@@ -179,7 +179,7 @@ Compatible flags for this model: --thinking-budget (Anthropic reasoning control)
    ```bash
    # Test with a thinking-capable model (system should detect compatibility)
    # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 71 --model openai:o4-mini --thinking-effort medium
+# Example: uv run gh-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 71 --model openai:o4-mini --thinking-effort medium
    ```
 
 ## Success Metrics

--- a/tasks/archive/github-attachment-collection.md
+++ b/tasks/archive/github-attachment-collection.md
@@ -149,7 +149,7 @@ Add options to collect command:
    ```bash
    # After single-issue collection merges, test with:
    # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --download-attachments
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --download-attachments
    ```
 3. **Validation Checklist** (once single-issue collection is available):
    - [ ] Test with USER_PROVIDED_ORG/USER_PROVIDED_REPO issue #71 (has all attachment types)
@@ -189,7 +189,7 @@ Add options to collect command:
 ```bash
 # Test with issue #71 which has multiple attachment types
 # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --download-attachments
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER --download-attachments
 
 # Expected attachments in issue #71:
 # - Images: ![Image](https://github.com/user-attachments/assets/...)

--- a/tasks/archive/github-issue-collection.md
+++ b/tasks/archive/github-issue-collection.md
@@ -37,7 +37,7 @@ Implement basic GitHub issue collection using the GitHub REST API. Focus on sear
 
 **CLI Interface:**
 ```bash
-uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --labels bug --limit 5
+uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --labels bug --limit 5
 ```
 
 **Pydantic Models Needed:**
@@ -138,9 +138,9 @@ Build GitHub search queries like: `repo:USER_PROVIDED_ORG/USER_PROVIDED_REPO is:
 
 **Validation:**
 ✅ CLI commands work correctly:
-- `uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3` (requires GITHUB_TOKEN)
-- `uv run github-analysis status` (shows storage statistics)
-- `uv run github-analysis --help` (shows all commands)
+- `uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3` (requires GITHUB_TOKEN)
+- `uv run gh-analysis status` (shows storage statistics)
+- `uv run gh-analysis --help` (shows all commands)
 
 ✅ All tests pass: `uv run pytest tests/test_github_client/ tests/test_storage/ -v` (48/48 tests)
 
@@ -148,4 +148,4 @@ Build GitHub search queries like: `repo:USER_PROVIDED_ORG/USER_PROVIDED_REPO is:
 
 **CLI Structure Fixed:**
 - Corrected command structure from nested `collect collect` to direct `collect`
-- Commands now work as documented: `github-analysis collect --org X --repo Y`
+- Commands now work as documented: `gh-analysis collect --org X --repo Y`

--- a/tasks/archive/github-issue-label-updates.md
+++ b/tasks/archive/github-issue-label-updates.md
@@ -96,7 +96,7 @@ The following label changes have been applied based on AI analysis:
 **Command Structure:**
 ```bash
 # New subcommand under main CLI
-uv run github-analysis update-labels [OPTIONS]
+uv run gh-analysis update-labels [OPTIONS]
 
 # Filtering options
 --org TEXT                    # Organization name (required if --repo)
@@ -117,13 +117,13 @@ uv run github-analysis update-labels [OPTIONS]
 **Command Examples:**
 ```bash
 # Preview changes for specific issue
-uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --issue-number 17 --dry-run
+uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --issue-number 17 --dry-run
 
 # Update all issues for a repository with high confidence
-uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --min-confidence 0.9
+uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --min-confidence 0.9
 
 # Update specific issue with custom confidence
-uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --issue-number 17 --min-confidence 0.75
+uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo actian-replicated --issue-number 17 --min-confidence 0.75
 ```
 
 ### 5. File Structure

--- a/tasks/archive/open-source-repository-sanitization.md
+++ b/tasks/archive/open-source-repository-sanitization.md
@@ -68,20 +68,20 @@ Sanitize the GitHub issue analysis repository for open source release by removin
 **Instead of hardcoded examples like:**
 ```bash
 # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 ```
 
 **Use runtime prompts like:**
 ```bash
 # Ask user for test repository
-uv run github-analysis collect --org YOUR_ORG --repo YOUR_REPO --issue-number 123 --dry-run
+uv run gh-analysis collect --org YOUR_ORG --repo YOUR_REPO --issue-number 123 --dry-run
 ```
 
 **Task templates should instruct:**
 ```markdown
 **Validation:**
 - Ask user to provide a test organization and repository for validation
-- Run with --dry-run flag: `uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run`
+- Run with --dry-run flag: `uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run`
 ```
 
 ### Implementation Approach
@@ -180,7 +180,7 @@ Files to update: All files in tasks/ and tasks/archive/ directories containing '
 
 Required changes:
 1. Replace hardcoded customer examples with instructions like: 'Ask user to provide test organization and repository for validation'
-2. Update validation sections to use pattern: 'uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run'
+2. Update validation sections to use pattern: 'uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run'
 3. Ensure all validation commands include --dry-run flag
 4. Use consistent instruction pattern: 'Ask user to provide test organization/repository at runtime'
 
@@ -226,7 +226,7 @@ git ls-tree -r HEAD --name-only | xargs grep -l "USER_PROVIDED_ORG" | wc -l
 git ls-tree -r HEAD --name-only | xargs grep -l "USER_PROVIDED_ORG\|pixee-replicated" || echo "Clean!"
 
 # Test CLI with generic examples
-uv run github-analysis collect --help | grep -E "(YOUR_ORG|example-org)"
+uv run gh-analysis collect --help | grep -E "(YOUR_ORG|example-org)"
 
 # Ensure quality checks pass
 uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest

--- a/tasks/archive/repository-exclusion-for-org-collection.md
+++ b/tasks/archive/repository-exclusion-for-org-collection.md
@@ -42,19 +42,19 @@ Currently, organization-wide collection (`--org orgname`) includes all repositor
 ```bash
 # Exclude single repository
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo
 
 # Exclude multiple repositories (multiple flags)
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --exclude-repo test-repo
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --exclude-repo test-repo
 
 # Exclude multiple repositories (comma-separated)
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repos "private-repo,test-repo,archived-repo"
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repos "private-repo,test-repo,archived-repo"
 
 # Mix both approaches
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --exclude-repos "test-repo,archived-repo"
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --exclude-repos "test-repo,archived-repo"
 ```
 
 ### 2. GitHub Search Query Modification
@@ -283,23 +283,23 @@ Follow existing test patterns in the codebase:
 ```bash
 # Test basic exclusion functionality
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --limit 5
 
 # Test multiple exclusions
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repos "repo1,repo2,repo3" --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repos "repo1,repo2,repo3" --limit 5
 
 # Test with existing filters
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --labels bug --state closed --limit 10
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo private-repo --labels bug --state closed --limit 10
 
 # Verify query building in logs
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repos "test-repo,archived-repo" --limit 1
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repos "test-repo,archived-repo" --limit 1
 
 # Test error handling
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --exclude-repo "invalid repo name" --limit 1
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --exclude-repo "invalid repo name" --limit 1
 ```
 
 ## Automated Test Commands (No API Keys Required)

--- a/tasks/archive/single-issue-collection.md
+++ b/tasks/archive/single-issue-collection.md
@@ -23,15 +23,15 @@ Enhance the existing `collect` command to support flexible issue collection patt
    ```bash
    # Single issue collection (new)
    # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
    
    # Organization-wide search (new) - search all repos in org
    # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --limit 20
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --limit 20
    
    # Repository-specific bulk collection (existing, enhanced)
    # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 10
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 10
    ```
 
 3. **Collection Mode Logic**
@@ -121,7 +121,7 @@ Enhance the existing `collect` command to support flexible issue collection patt
 ```bash
 # Test with the specific issue mentioned
 # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 
 # Expected: Successfully collect issue #71 "Weird Behavior with RunPods"
 # Verify: File created at data/issues/ORG_REPO_issue_NUMBER.json
@@ -133,7 +133,7 @@ Enhance the existing `collect` command to support flexible issue collection patt
 ```bash
 # Test organization-wide search
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --limit 10
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --limit 10
 
 # Expected: Collects 10 closed issues from any repo in USER_PROVIDED_ORG org
 # Verify: Issues from multiple repositories are collected
@@ -145,7 +145,7 @@ Enhance the existing `collect` command to support flexible issue collection patt
 ```bash
 # Test repository collection uses closed by default
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
 
 # Expected: Collects 5 closed issues from provided repo only
 # Verify: All collected issues have "state": "closed"
@@ -156,13 +156,13 @@ Enhance the existing `collect` command to support flexible issue collection patt
 ```bash
 # Test non-existent issue
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 99999
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 99999
 
 # Expected: Clear error message about issue not found
 # Verify: No file created, proper exit code
 
 # Test invalid parameter combinations
-uv run github-analysis collect --issue-number 71
+uv run gh-analysis collect --issue-number 71
 
 # Expected: Error message requiring both --org and --repo for single issue mode
 ```
@@ -171,7 +171,7 @@ uv run github-analysis collect --issue-number 71
 ```bash
 # Test existing bulk collection still works with explicit state
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --state open --limit 3
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --state open --limit 3
 
 # Expected: Collects 3 open issues (overriding new default)
 # Verify: All collected issues have "state": "open"

--- a/tasks/archive/thinking-models-support.md
+++ b/tasks/archive/thinking-models-support.md
@@ -121,27 +121,27 @@ AI_THINKING_SUMMARY=detailed
 **Validation:**
 ```bash
 # Test thinking model configurations
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
   --model openai:o1-mini --thinking-effort high \
   --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
   --model anthropic:claude-3-5-sonnet-latest --thinking-budget 2048 \
   --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 
 # Test validation errors
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
   --model openai:gpt-4o --thinking-effort high
 # Should show helpful error with model suggestions
 
 # Test environment variables
 export AI_THINKING_EFFORT=medium
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
   --model openai:o1-mini \
   --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 
 # Test backward compatibility
-uv run github-analysis process product-labeling \
+uv run gh-analysis process product-labeling \
   --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
 # Should work exactly as before
 

--- a/tasks/automatic-batch-splitting-multi-batch-importing.md
+++ b/tasks/automatic-batch-splitting-multi-batch-importing.md
@@ -34,22 +34,22 @@ Implement automatic batch splitting for large issue collections using a fixed 30
 ## New Operations
 ```bash
 # Existing commands work seamlessly with automatic splitting
-uv run github-analysis batch submit product-labeling --org myorg  # Auto-splits if >30 issues
+uv run gh-analysis batch submit product-labeling --org myorg  # Auto-splits if >30 issues
 
 # Enhanced status shows group progress  
-uv run github-analysis batch status <group-id>  # Shows all batches in group
-uv run github-analysis batch status <job-id>    # Individual batch status
+uv run gh-analysis batch status <group-id>  # Shows all batches in group
+uv run gh-analysis batch status <job-id>    # Individual batch status
 
 # Group-level operations
-uv run github-analysis batch group-collect <group-id>  # Collect all results
-uv run github-analysis batch list --groups            # Show batch groups
+uv run gh-analysis batch group-collect <group-id>  # Collect all results
+uv run gh-analysis batch list --groups            # Show batch groups
 
 # Preview splitting
-uv run github-analysis batch submit product-labeling --org myorg --dry-run  # Preview split plan
+uv run gh-analysis batch submit product-labeling --org myorg --dry-run  # Preview split plan
 
 # Advanced group management
-uv run github-analysis batch group-cancel <group-id>
-uv run github-analysis batch group-retry <group-id> --failed-only
+uv run gh-analysis batch group-cancel <group-id>
+uv run gh-analysis batch group-retry <group-id> --failed-only
 ```
 
 ## New Functionality
@@ -307,46 +307,46 @@ def submit(
 ```bash
 # 1. Test splitting preview for small collections
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --dry-run --limit 10
+# Example: uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --dry-run --limit 10
 
 # 2. Test splitting preview for large collections
 # Ask user to provide test organization for validation  
-# Example: uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --dry-run --limit 100
+# Example: uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --dry-run --limit 100
 ```
 
 ### **Automatic Splitting**
 ```bash
 # 3. Test small batch (no splitting required)
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --limit 20
+# Example: uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --limit 20
 
 # 4. Test large batch (auto-splitting into 30-issue chunks)
 # Ask user to provide test organization for validation
-# Example: uv run github-analysis batch submit product-labeling --org USER_PROVIDED_ORG --limit 80
+# Example: uv run gh-analysis batch submit product-labeling --org USER_PROVIDED_ORG --limit 80
 
 # 5. Verify group creation and tracking
-uv run github-analysis batch list --groups
+uv run gh-analysis batch list --groups
 ```
 
 ### **Multi-Batch Management**
 ```bash
 # 6. Monitor group progress
-uv run github-analysis batch status <group-id>
+uv run gh-analysis batch status <group-id>
 
 # 7. Test individual batch status within group
-uv run github-analysis batch status <individual-job-id>
+uv run gh-analysis batch status <individual-job-id>
 
 # 8. Collect group results when complete
-uv run github-analysis batch group-collect <group-id>
+uv run gh-analysis batch group-collect <group-id>
 ```
 
 ### **Integration and Edge Cases**
 ```bash
 # 9. Test edge case: exactly 30 issues (no splitting)
-uv run github-analysis batch submit product-labeling --org test-org --limit 30
+uv run gh-analysis batch submit product-labeling --org test-org --limit 30
 
 # 10. Test edge case: 31 issues (splits into 30 + 1)
-uv run github-analysis batch submit product-labeling --org test-org --limit 31
+uv run gh-analysis batch submit product-labeling --org test-org --limit 31
 
 # 11. Test error handling
 # Submit batch, cancel one job in group, verify partial collection works
@@ -358,12 +358,12 @@ uv run github-analysis batch submit product-labeling --org test-org --limit 31
 ### **Backward Compatibility**
 ```bash
 # 13. Verify existing small batch workflows unchanged
-uv run github-analysis batch submit product-labeling --org test-org --repo small-repo
+uv run gh-analysis batch submit product-labeling --org test-org --repo small-repo
 
 # 14. Verify existing CLI commands work with groups
-uv run github-analysis batch list
-uv run github-analysis batch status <job-id>
-uv run github-analysis batch collect <job-id>
+uv run gh-analysis batch list
+uv run gh-analysis batch status <job-id>
+uv run gh-analysis batch collect <job-id>
 ```
 
 ## Success Criteria

--- a/tasks/clarify-confidence-scores.md
+++ b/tasks/clarify-confidence-scores.md
@@ -242,21 +242,21 @@ uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv 
 
 # 2. Collect fresh test data (no existing data in new branch)
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3
 
 # 3. Test AI processing with real issue (MUST actually run to generate results for testing)
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 71
+# Example: uv run gh-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number 71
 
 # 4. Test confidence filtering with different thresholds (ALWAYS use --dry-run)
-# Example: uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.9 --dry-run
-# Example: uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.5 --dry-run
-# Example: uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.8 --dry-run
+# Example: uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.9 --dry-run
+# Example: uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.5 --dry-run
+# Example: uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --min-confidence 0.8 --dry-run
 
 # 5. Test full processing pipeline with all collected issues
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
-# Example: uv run github-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run
+# Example: uv run gh-analysis process product-labeling --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
+# Example: uv run gh-analysis update-labels --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --dry-run
 
 # 6. Verify JSON output structure manually
 # Example: cat data/results/ORG_REPO_issue_NUMBER_product-labeling.json | jq '.analysis | keys'

--- a/tasks/cli-review-and-normalization.md
+++ b/tasks/cli-review-and-normalization.md
@@ -60,7 +60,7 @@ Standardize CLI option patterns across all commands to ensure consistent shortha
 ## Phase 3: Verification and Testing
 
 7. **Verify `-h` for `--help`**:
-   - Test that `uv run github-analysis collect -h` works correctly
+   - Test that `uv run gh-analysis collect -h` works correctly
    - If not working, investigate Typer configuration needed
    - Document findings and fix if necessary
 
@@ -133,21 +133,21 @@ uv run python -c "from github_issue_analysis.cli.options import ORG_OPTION, REPO
 **Phase 2 - Updated Commands:**
 ```bash
 # Test collect command with shorthand options
-uv run github-analysis collect -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER --dry-run
+uv run gh-analysis collect -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER --dry-run
 
 # Test batch command with shorthand options  
-uv run github-analysis batch submit product-labeling -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO --dry-run
+uv run gh-analysis batch submit product-labeling -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO --dry-run
 
 # Test process command with shorthand options
-uv run github-analysis process product-labeling -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER --dry-run
+uv run gh-analysis process product-labeling -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER --dry-run
 
 # Test update-labels with NEW shorthand options (most important)
-uv run github-analysis update-labels -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER -d
+uv run gh-analysis update-labels -o USER_PROVIDED_ORG -r USER_PROVIDED_REPO -i USER_PROVIDED_ISSUE_NUMBER -d
 
 # Test help shorthand works
-uv run github-analysis collect -h
-uv run github-analysis batch -h  
-uv run github-analysis update-labels -h
+uv run gh-analysis collect -h
+uv run gh-analysis batch -h  
+uv run gh-analysis update-labels -h
 ```
 
 **Phase 3 - Consistency Validation:**

--- a/tasks/duckdb-integration-phase1-foundation.md
+++ b/tasks/duckdb-integration-phase1-foundation.md
@@ -745,21 +745,21 @@ class TestQueryCommands:
 uv add duckdb
 
 # 2. Verify existing data
-uv run github-analysis status
+uv run gh-analysis status
 
 # 3. Collect some sample data if needed
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
 ```
 
 ### **Database Functionality**
 ```bash
 # 4. Check database auto-creation
-uv run github-analysis status
+uv run gh-analysis status
 # Should show: "Database Issues: X" and sync status
 
 # 5. Manual sync test
-uv run github-analysis sync
+uv run gh-analysis sync
 # Should show sync results
 
 # 6. Verify database file exists
@@ -769,31 +769,31 @@ ls -la data/issues.duckdb
 ### **Query Interface**
 ```bash
 # 7. List available queries
-uv run github-analysis query list
+uv run gh-analysis query list
 
 # 8. Test query aliases
-uv run github-analysis query alias open_issues
-uv run github-analysis query alias label_summary
+uv run gh-analysis query alias open_issues
+uv run gh-analysis query alias label_summary
 
 # 9. Test custom SQL
-uv run github-analysis query sql "SELECT COUNT(*) as total FROM issues"
-uv run github-analysis query sql "SELECT org, repo, COUNT(*) FROM issues GROUP BY org, repo" --format json
+uv run gh-analysis query sql "SELECT COUNT(*) as total FROM issues"
+uv run gh-analysis query sql "SELECT org, repo, COUNT(*) FROM issues GROUP BY org, repo" --format json
 
 # 10. Test output formats
-uv run github-analysis query alias open_issues --format csv --limit 3
+uv run gh-analysis query alias open_issues --format csv --limit 3
 ```
 
 ### **Error Handling**
 ```bash
 # 11. Test without DuckDB (temporarily uninstall)
 uv remove duckdb
-uv run github-analysis status  # Should work, show "Database: Disabled"
-uv run github-analysis query sql "SELECT 1"  # Should show error message
+uv run gh-analysis status  # Should work, show "Database: Disabled"
+uv run gh-analysis query sql "SELECT 1"  # Should show error message
 uv add duckdb  # Restore
 
 # 12. Test invalid queries
-uv run github-analysis query sql "INVALID SQL"  # Should show error
-uv run github-analysis query alias invalid_query  # Should show error
+uv run gh-analysis query sql "INVALID SQL"  # Should show error
+uv run gh-analysis query alias invalid_query  # Should show error
 ```
 
 ### **Quality Assurance**
@@ -807,8 +807,8 @@ uv run ruff check --fix && uv run black . && uv run mypy .
 
 # 15. Integration test
 # Ask user to provide test organization, repository, and issue number for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
-# Example: uv run github-analysis query sql "SELECT title, state FROM issues WHERE repo = 'USER_PROVIDED_REPO'"
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --issue-number USER_PROVIDED_ISSUE_NUMBER
+# Example: uv run gh-analysis query sql "SELECT title, state FROM issues WHERE repo = 'USER_PROVIDED_REPO'"
 ```
 
 ## Acceptance Criteria
@@ -826,7 +826,7 @@ uv run ruff check --fix && uv run black . && uv run mypy .
 - [ ] All quality checks pass (ruff, black, mypy)
 - [ ] Clear documentation of query capabilities
 
-**Success Metric**: User can collect issues normally (unchanged workflow) and then use `uv run github-analysis query alias open_issues` to get rich insights not possible with JSON alone.
+**Success Metric**: User can collect issues normally (unchanged workflow) and then use `uv run gh-analysis query alias open_issues` to get rich insights not possible with JSON alone.
 
 ## Agent Notes
 [Document your implementation approach, database design decisions, and query interface choices]

--- a/tasks/duckdb-integration-phase2-ai-processing.md
+++ b/tasks/duckdb-integration-phase2-ai-processing.md
@@ -82,13 +82,13 @@ QUERY_ALIASES['label_summary'] = {
 **Usage Examples:**
 ```bash
 # Show label analysis for all repositories
-uv run github-analysis query alias label_summary
+uv run gh-analysis query alias label_summary
 
 # Filter to specific repository
-uv run github-analysis query sql "SELECT * FROM (${label_summary_sql}) WHERE repository = 'replicated/kots'"
+uv run gh-analysis query sql "SELECT * FROM (${label_summary_sql}) WHERE repository = 'replicated/kots'"
 
 # Find under-labeled issues
-uv run github-analysis query sql "SELECT * FROM (${label_summary_sql}) WHERE recommendation_impact = 'Under-labeled'"
+uv run gh-analysis query sql "SELECT * FROM (${label_summary_sql}) WHERE recommendation_impact = 'Under-labeled'"
 ```
 
 ### **AI Results Schema Extension**
@@ -812,11 +812,11 @@ class TestAIProcessingPipeline:
 ### **Setup and Data Preparation**
 ```bash
 # 1. Ensure Phase 1 is working
-uv run github-analysis status  # Should show database enabled
+uv run gh-analysis status  # Should show database enabled
 
 # 2. Collect some test data
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 3
 
 # 3. Run some AI processing to have existing results
 # (This assumes AI processing is available from previous tasks)
@@ -825,31 +825,31 @@ uv run github-analysis status  # Should show database enabled
 ### **AI Results Integration**
 ```bash
 # 4. Sync existing AI results to database
-uv run github-analysis sync --ai-results
+uv run gh-analysis sync --ai-results
 
 # 5. Check AI analytics
-uv run github-analysis process-query analytics
+uv run gh-analysis process-query analytics
 ```
 
 ### **Pipeline Functionality**
 ```bash
 # 6. Test missing analysis processing
-uv run github-analysis process-query missing product-labeling --limit 2
+uv run gh-analysis process-query missing product-labeling --limit 2
 
 # 7. Test reprocessing low confidence
-uv run github-analysis process-query reprocess product-labeling --threshold 0.8 --limit 1
+uv run gh-analysis process-query reprocess product-labeling --threshold 0.8 --limit 1
 
 # 8. Test custom query processing
-uv run github-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state = 'closed'" --limit 1
+uv run gh-analysis process-query custom product-labeling "SELECT * FROM issues WHERE state = 'closed'" --limit 1
 ```
 
 ### **Advanced Queries**
 ```bash
 # 9. Query AI results through SQL
-uv run github-analysis query sql "SELECT processor, AVG(confidence), COUNT(*) FROM ai_results GROUP BY processor"
+uv run gh-analysis query sql "SELECT processor, AVG(confidence), COUNT(*) FROM ai_results GROUP BY processor"
 
 # 10. Find issues needing attention
-uv run github-analysis query sql "SELECT org, repo, number FROM issues i LEFT JOIN ai_results ar ON i.id = ar.issue_id WHERE ar.id IS NULL AND i.state = 'open'"
+uv run gh-analysis query sql "SELECT org, repo, number FROM issues i LEFT JOIN ai_results ar ON i.id = ar.issue_id WHERE ar.id IS NULL AND i.state = 'open'"
 ```
 
 ### **Quality Assurance**
@@ -874,10 +874,10 @@ uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv 
 - [ ] Error handling and progress reporting
 
 **Success Metrics**: 
-1. User can run `uv run github-analysis process-query missing product-labeling --state open --limit 10` to intelligently select and process issues
-2. `uv run github-analysis process-query analytics` shows comprehensive AI processing insights
+1. User can run `uv run gh-analysis process-query missing product-labeling --state open --limit 10` to intelligently select and process issues
+2. `uv run gh-analysis process-query analytics` shows comprehensive AI processing insights
 3. Processing pipeline enables complex workflows like "process open issues from specific repos that don't have product labels"
-4. Extended `uv run github-analysis query alias label_summary` shows current vs AI-recommended label usage with impact analysis
+4. Extended `uv run gh-analysis query alias label_summary` shows current vs AI-recommended label usage with impact analysis
 
 ## Agent Notes
 [Document your pipeline design decisions, integration approach, and performance optimizations]

--- a/tasks/duckdb-integration-phase3-issue-sync.md
+++ b/tasks/duckdb-integration-phase3-issue-sync.md
@@ -964,50 +964,50 @@ class TestUpdateStrategy:
 ### **Setup and Preparation**
 ```bash
 # 1. Ensure DuckDB Phase 1 is working with some data
-uv run github-analysis status
+uv run gh-analysis status
 
 # 2. Collect some test issues (mix of open/closed)
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 5
 ```
 
 ### **Core Feature Testing: Non-Closed Issues**
 ```bash
 # 3. Test the verified feature - update non-closed issues (dry run first)
-uv run github-analysis update open-issues --dry-run
-uv run github-analysis update open-issues --limit 3
+uv run gh-analysis update open-issues --dry-run
+uv run gh-analysis update open-issues --limit 3
 
 # 4. Verify changes detected
-uv run github-analysis update changes --days 1
+uv run gh-analysis update changes --days 1
 
 # 5. Check sync history
-uv run github-analysis update history --days 1
+uv run gh-analysis update history --days 1
 ```
 
 ### **Additional Update Strategies**
 ```bash
 # 6. Test stale issue updates
-uv run github-analysis update stale --days 1 --limit 2 --dry-run
-uv run github-analysis update stale --days 1 --limit 2
+uv run gh-analysis update stale --days 1 --limit 2 --dry-run
+uv run gh-analysis update stale --days 1 --limit 2
 
 # 7. Test repository updates
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis update repo USER_PROVIDED_ORG USER_PROVIDED_REPO --limit 2 --dry-run
+# Example: uv run gh-analysis update repo USER_PROVIDED_ORG USER_PROVIDED_REPO --limit 2 --dry-run
 
 # 8. Test smart update strategy
-uv run github-analysis update smart --limit 5 --dry-run
+uv run gh-analysis update smart --limit 5 --dry-run
 ```
 
 ### **Data Verification**
 ```bash
 # 9. Query updated issues
-uv run github-analysis query sql "SELECT org, repo, number, state, collection_timestamp FROM issues ORDER BY collection_timestamp DESC LIMIT 5"
+uv run gh-analysis query sql "SELECT org, repo, number, state, collection_timestamp FROM issues ORDER BY collection_timestamp DESC LIMIT 5"
 
 # 10. Check for state changes
-uv run github-analysis query sql "SELECT COUNT(*) FROM issue_updates WHERE update_type = 'state_change'"
+uv run gh-analysis query sql "SELECT COUNT(*) FROM issue_updates WHERE update_type = 'state_change'"
 
 # 11. Verify sync tracking
-uv run github-analysis query sql "SELECT sync_type, COUNT(*) FROM sync_history GROUP BY sync_type"
+uv run gh-analysis query sql "SELECT sync_type, COUNT(*) FROM sync_history GROUP BY sync_type"
 ```
 
 ### **Quality Assurance**
@@ -1034,7 +1034,7 @@ uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv 
 - [ ] Performance optimization for large update batches
 
 **Success Metrics**:
-1. `uv run github-analysis update open-issues` successfully finds and updates previously non-closed issues
+1. `uv run gh-analysis update open-issues` successfully finds and updates previously non-closed issues
 2. Change detection accurately identifies state changes (open→closed, etc.)
 3. Update history shows clear audit trail of sync operations
 4. Smart update strategy efficiently prioritizes most important issues

--- a/tasks/recommendation-management-system-phase2.md
+++ b/tasks/recommendation-management-system-phase2.md
@@ -74,9 +74,9 @@ class GitHubIntegration:
 ```
 
 ### 3. CLI Commands (Phase 2)
-- `uv run github-analysis recommendations bulk-approve [filters]` - Bulk approve high-confidence recommendations
-- `uv run github-analysis recommendations apply-approved [filters]` - Apply approved recommendations to GitHub
-- `uv run github-analysis recommendations archive-applied [filters]` - Archive completed recommendations
+- `uv run gh-analysis recommendations bulk-approve [filters]` - Bulk approve high-confidence recommendations
+- `uv run gh-analysis recommendations apply-approved [filters]` - Apply approved recommendations to GitHub
+- `uv run gh-analysis recommendations archive-applied [filters]` - Archive completed recommendations
 
 ## Acceptance Criteria (Phase 2)
 
@@ -184,19 +184,19 @@ class TestBulkCLI:
     def test_bulk_approve_command(self):
         """Test bulk approve CLI command."""
         # Create high-confidence pending recommendations
-        # Run: uv run github-analysis recommendations bulk-approve --min-confidence 0.9
+        # Run: uv run gh-analysis recommendations bulk-approve --min-confidence 0.9
         # Verify correct recommendations approved
         
     def test_apply_approved_command_with_filters(self):
         """Test apply approved command with org/repo filters."""
         # Create approved recommendations for multiple orgs
-        # Run: uv run github-analysis recommendations apply-approved --org testorg --dry-run
+        # Run: uv run gh-analysis recommendations apply-approved --org testorg --dry-run
         # Verify only testorg recommendations included in preview
         
     def test_archive_applied_command(self):
         """Test archive command."""
         # Create old applied recommendations
-        # Run: uv run github-analysis recommendations archive-applied --older-than-days 1
+        # Run: uv run gh-analysis recommendations archive-applied --older-than-days 1
         # Verify files moved to archive directory
 ```
 

--- a/tasks/recommendation-management-system.md
+++ b/tasks/recommendation-management-system.md
@@ -688,8 +688,8 @@ class ProductLabelingProcessor:
 ```
 
 **CLI Command Modifications:**
-- Add `--reprocess` flag to `uv run github-analysis process product-labeling` 
-- Add `--reprocess` flag to `uv run github-analysis batch submit product-labeling`
+- Add `--reprocess` flag to `uv run gh-analysis process product-labeling` 
+- Add `--reprocess` flag to `uv run gh-analysis batch submit product-labeling`
 - Both commands check recommendation status before AI submission
 
 ### 6. CLI Interface Implementation
@@ -1132,41 +1132,41 @@ class TestRecommendationsCLI:
     def test_discover_command(self):
         """Test recommendation discovery CLI command."""
         # Create mock AI result and issue files
-        # Run: uv run github-analysis recommendations discover
+        # Run: uv run gh-analysis recommendations discover
         # Verify command succeeds
         # Verify recommendation status files created
         
     def test_list_command_no_filters(self):
         """Test list command with no filters shows all recommendations."""
         # Create 3 recommendation status files
-        # Run: uv run github-analysis recommendations list
+        # Run: uv run gh-analysis recommendations list
         # Verify output shows all 3 recommendations in table format
         
     def test_list_command_with_filters(self):
         """Test list command with various filter combinations."""
         # Create recommendations with different org, status, confidence
-        # Test --org filter: uv run github-analysis recommendations list --org testorg
-        # Test --status filter: uv run github-analysis recommendations list --status pending
+        # Test --org filter: uv run gh-analysis recommendations list --org testorg
+        # Test --status filter: uv run gh-analysis recommendations list --status pending
         # Test --min-confidence filter
         # Verify each filter returns only matching recommendations
         
     def test_summary_command(self):
         """Test summary dashboard command."""
         # Create recommendations with various statuses and products
-        # Run: uv run github-analysis recommendations summary
+        # Run: uv run gh-analysis recommendations summary
         # Verify statistics table displayed
         # Verify counts match created recommendations
         
     def test_review_session_command_no_recommendations(self):
         """Test review session with no pending recommendations."""
         # Ensure no recommendation files exist
-        # Run: uv run github-analysis recommendations review-session
+        # Run: uv run gh-analysis recommendations review-session
         # Verify shows "No recommendations found" message
         
     def test_review_session_command_with_filters(self):
         """Test review session command filters work correctly."""
         # Create recommendations with different orgs and confidence levels
-        # Run: uv run github-analysis recommendations review-session --org testorg --min-confidence 0.8
+        # Run: uv run gh-analysis recommendations review-session --org testorg --min-confidence 0.8
         # Verify only matching recommendations are included in session
 ```
 
@@ -1222,12 +1222,12 @@ Create comprehensive user documentation at `docs/recommendation-workflow.md` cov
 ### Setup and Discovery
 ```bash
 # 1. Ensure we have AI results to work with (use your actual org/repo)
-uv run github-analysis collect --org YOUR_ORG --repo YOUR_REPO --limit 5
-uv run github-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO
+uv run gh-analysis collect --org YOUR_ORG --repo YOUR_REPO --limit 5
+uv run gh-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO
 
 # 2. Test recommendation discovery
-uv run github-analysis recommendations discover
-uv run github-analysis recommendations summary
+uv run gh-analysis recommendations discover
+uv run gh-analysis recommendations summary
 
 # 3. Verify status files are created
 ls -la data/recommendation_status/
@@ -1236,27 +1236,27 @@ ls -la data/recommendation_status/
 ### Core Functionality
 ```bash
 # 4. Test recommendation listing and filtering
-uv run github-analysis recommendations list
-uv run github-analysis recommendations list --status pending --min-confidence 0.8
-uv run github-analysis recommendations list --product kots --confidence-tier high
+uv run gh-analysis recommendations list
+uv run gh-analysis recommendations list --status pending --min-confidence 0.8
+uv run gh-analysis recommendations list --product kots --confidence-tier high
 
 # 5. Test interactive review session (main feature)
-uv run github-analysis recommendations review-session
-uv run github-analysis recommendations review-session --org YOUR_ORG --min-confidence 0.8
+uv run gh-analysis recommendations review-session
+uv run gh-analysis recommendations review-session --org YOUR_ORG --min-confidence 0.8
 
 # 6. Verify status changes persist
-uv run github-analysis recommendations list --status approved
-uv run github-analysis recommendations summary
+uv run gh-analysis recommendations list --status approved
+uv run gh-analysis recommendations summary
 ```
 
 ### Reprocessing Safety
 ```bash
 # 7. Test reprocessing safety (should skip reviewed recommendations)
-uv run github-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO
+uv run gh-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO
 # Should skip issues with reviewed recommendations
 
 # 8. Test reprocess override
-uv run github-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO --reprocess
+uv run gh-analysis process product-labeling --org YOUR_ORG --repo YOUR_REPO --reprocess
 # Should reprocess all issues regardless of status
 ```
 
@@ -1293,10 +1293,10 @@ uv run black . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv 
 - [ ] **User Documentation**: Complete workflow guide in `docs/recommendation-workflow.md`
 
 ### CLI Commands (Phase 1)
-- [ ] `uv run github-analysis recommendations discover` - Scan for new recommendations
-- [ ] `uv run github-analysis recommendations summary` - Dashboard view of recommendations
-- [ ] `uv run github-analysis recommendations list [filters]` - List and filter recommendations  
-- [ ] `uv run github-analysis recommendations review-session [filters]` - Interactive review workflow
+- [ ] `uv run gh-analysis recommendations discover` - Scan for new recommendations
+- [ ] `uv run gh-analysis recommendations summary` - Dashboard view of recommendations
+- [ ] `uv run gh-analysis recommendations list [filters]` - List and filter recommendations  
+- [ ] `uv run gh-analysis recommendations review-session [filters]` - Interactive review workflow
 
 ## Success Metrics (Phase 1)
 

--- a/tasks/storage-querying-system.md
+++ b/tasks/storage-querying-system.md
@@ -69,23 +69,23 @@ class StorageManager:
 
 **List Command:**
 ```bash
-uv run github-analysis list --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
-uv run github-analysis list --labels bug,enhancement --state open
-uv run github-analysis list --created-after 2024-01-01 --count-only
-uv run github-analysis list --title-contains "crash" --limit 10
+uv run gh-analysis list --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO
+uv run gh-analysis list --labels bug,enhancement --state open
+uv run gh-analysis list --created-after 2024-01-01 --count-only
+uv run gh-analysis list --title-contains "crash" --limit 10
 ```
 
 **Stats Command:**
 ```bash  
-uv run github-analysis stats
-uv run github-analysis stats --org USER_PROVIDED_ORG
+uv run gh-analysis stats
+uv run gh-analysis stats --org USER_PROVIDED_ORG
 ```
 
 **Clean Command:**
 ```bash
-uv run github-analysis clean --dry-run
-uv run github-analysis clean --older-than 30d
-uv run github-analysis clean --repo archived-repo
+uv run gh-analysis clean --dry-run
+uv run gh-analysis clean --older-than 30d
+uv run gh-analysis clean --repo archived-repo
 ```
 
 **CLI Implementation:**
@@ -172,12 +172,12 @@ def validate_all_issues() -> Dict[str, List[str]]:
 [Document your query design decisions, performance optimizations, and CLI interface choices]
 
 **Validation:**
-- Ensure issues collected first: `uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 10`
-- Test listing: `uv run github-analysis list --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO`
-- Test filtering: `uv run github-analysis list --labels bug --state open --limit 5`
-- Test stats: `uv run github-analysis stats`
-- Test count-only: `uv run github-analysis list --count-only`
-- Test clean dry-run: `uv run github-analysis clean --dry-run`
+- Ensure issues collected first: `uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 10`
+- Test listing: `uv run gh-analysis list --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO`
+- Test filtering: `uv run gh-analysis list --labels bug --state open --limit 5`
+- Test stats: `uv run gh-analysis stats`
+- Test count-only: `uv run gh-analysis list --count-only`
+- Test clean dry-run: `uv run gh-analysis clean --dry-run`
 - Verify performance with larger datasets (100+ issues)
 - Ensure all tests pass: `uv run pytest tests/test_storage/ -v`
 - Verify code quality: `uv run ruff check && uv run black . && uv run mypy .`

--- a/tasks/streaming-attachment-downloads.md
+++ b/tasks/streaming-attachment-downloads.md
@@ -21,7 +21,7 @@ GitHub attachment downloads are failing with HTTP 400 Bad Request errors during 
 **Exact Command That Triggered the Failures:**
 ```bash
 # Ask user to provide test organization and repository for validation
-# Example: uv run github-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 20
+# Example: uv run gh-analysis collect --org USER_PROVIDED_ORG --repo USER_PROVIDED_REPO --limit 20
 ```
 
 **System Context:**

--- a/tests/test_cli/test_recommendations.py
+++ b/tests/test_cli/test_recommendations.py
@@ -95,7 +95,7 @@ class TestRecommendationsCLI:
             # Create mock AI result and issue files
             self.create_mock_ai_result(Path(temp_dir), "testorg", "testrepo", 123)
 
-            # Run: uv run github-analysis recommendations discover
+            # Run: uv run gh-analysis recommendations discover
             result = runner.invoke(
                 app, ["recommendations", "discover", "--data-dir", temp_dir]
             )
@@ -137,7 +137,7 @@ class TestRecommendationsCLI:
                 with open(status_file, "w") as f:
                     json.dump(rec.model_dump(), f, default=str)
 
-            # Run: uv run github-analysis recommendations list
+            # Run: uv run gh-analysis recommendations list
             result = runner.invoke(
                 app, ["recommendations", "list", "--data-dir", temp_dir]
             )
@@ -266,7 +266,7 @@ class TestRecommendationsCLI:
                 with open(status_file, "w") as f:
                     json.dump(rec.model_dump(), f, default=str)
 
-            # Run: uv run github-analysis recommendations summary
+            # Run: uv run gh-analysis recommendations summary
             result = runner.invoke(
                 app, ["recommendations", "summary", "--data-dir", temp_dir]
             )
@@ -288,7 +288,7 @@ class TestRecommendationsCLI:
             status_dir = Path(temp_dir) / "recommendation_status"
             status_dir.mkdir(parents=True)
 
-            # Run: uv run github-analysis recommendations review-session
+            # Run: uv run gh-analysis recommendations review-session
             result = runner.invoke(
                 app, ["recommendations", "review-session", "--data-dir", temp_dir]
             )

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 ]
 
 [[package]]
-name = "github-issue-analysis"
+name = "gh-analysis"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- **Package name**: `github-issue-analysis` → `gh-analysis` 
- **CLI command**: `github-analysis` → `gh-analysis` (9 chars shorter)
- **PyPI ready**: Version 0.2.0, builds successfully
- **All references updated**: Documentation, tests, task files

## Testing
**Quality Checks (ALL PASSED):**
```bash
uv run ruff format . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest
# ✅ 76 files unchanged, all checks passed, no mypy issues, 369 tests passed
```

**Manual Validation:**
- ✅ `uv run gh-analysis --help` shows all commands  
- ✅ `uv build` creates `gh_analysis-0.2.0-py3-none-any.whl`
- ✅ CLI functionality preserved, just shorter command name

## Benefits
- **User experience**: `uvx gh-analysis` vs `uvx github-issue-analysis` 
- **PyPI ready**: Prepared for public release with user-friendly name
- **No breaking changes**: All functionality preserved, only command name shortened