### PR TITLE
chore: add snowflake passphrase to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ The memory+tool runners (suffix "_mt") require Snowflake access for enhanced tro
 **Required Environment Variables:**
 ```bash
 export SNOWFLAKE_ACCOUNT="your_account"
-export SNOWFLAKE_USER="your_user"  
+export SNOWFLAKE_USER="your_user"
 export SNOWFLAKE_PRIVATE_KEY_PATH="~/.snowflake/rsa_key.pem"
+export SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="your_passphrase"  # Optional: passphrase for private key
 export SNOWFLAKE_WAREHOUSE="COMPUTE_WH"
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Memory+Tool agents require Snowflake access for historical case data:
 
 ```bash
 export SNOWFLAKE_ACCOUNT="your_account"
-export SNOWFLAKE_USER="your_user"  
+export SNOWFLAKE_USER="your_user"
 export SNOWFLAKE_PRIVATE_KEY_PATH="~/.snowflake/rsa_key.pem"
+export SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="your_passphrase"  # Optional: passphrase for private key
 export SNOWFLAKE_WAREHOUSE="COMPUTE_WH"
 ```
 

--- a/tests/test_troubleshooting_functional.py
+++ b/tests/test_troubleshooting_functional.py
@@ -331,7 +331,7 @@ class TestEndToEnd:
                         repo="testrepo",
                         issue_number=123,
                         url=None,
-                        agent_name="o3_medium",
+                        agent_name="gpt5_mini_medium",
                         include_images=False,
                         limit_comments=None,
                         dry_run=False,


### PR DESCRIPTION
Document needing optional `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` environment variable for snowflake credentials