### PR TITLE
Fix CI container build hang and remove unnecessary files

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           context: .
           file: Containerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -62,7 +62,6 @@ COPY --from=builder /app/.venv /app/.venv
 COPY gh_analysis ./gh_analysis
 COPY scripts ./scripts
 COPY pyproject.toml uv.lock ./
-COPY tests ./tests
 
 # Fix ownership of .venv and application directory for appuser
 RUN chown -R appuser:appuser /app/.venv /app

--- a/test_cli.py
+++ b/test_cli.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""Test CLI functionality."""
-
-from gh_analysis.cli.collect import app
-
-if __name__ == "__main__":
-    app()


### PR DESCRIPTION
## Summary

- Remove ARM64 platform from container build (keep AMD64 only) to eliminate QEMU emulation overhead causing 10+ minute CI hangs
- Delete misplaced `test_cli.py` file from repository root
- Remove tests directory from production container image to reduce size
- Verify MCP functional tests continue to work without regression

## Testing

**Quality Checks (ALL PASSED):**
```bash
uv run ruff format . && uv run ruff check --fix --unsafe-fixes && uv run mypy . && uv run pytest
```
- ✅ ruff format: 131 files left unchanged
- ✅ ruff check: All checks passed!
- ✅ mypy: Success: no issues found in 45 source files  
- ✅ pytest: 425 passed, 1 skipped

**Manual Validation:**
- ✅ Container builds successfully: `podman build -t gh-analysis:test -f Containerfile .`
- ✅ Verified `/app/tests` directory no longer exists in production image
- ✅ All functional tests pass: `./scripts/test-container-functional.sh`
- ✅ MCP dependencies (sbctl, kubectl) still available
- ✅ CLI validation and data structure handling works correctly

## Expected Results

- **Build time**: Reduced from 10+ minutes to <5 minutes (eliminates ARM64 QEMU overhead)
- **Container size**: Reduced (tests directory no longer included)
- **Functionality**: No regression (tests mount as volumes when needed)