### PR TITLE
fix patched_process_response

### DIFF
--- a/gh_analysis/ai/pydantic_ai_patch.py
+++ b/gh_analysis/ai/pydantic_ai_patch.py
@@ -47,9 +47,13 @@ def apply_pydantic_ai_patch() -> None:
     # Based on context-experiments fix for tool call coordination
     original_process_response = OpenAIResponsesModel._process_response
 
-    def patched_process_response(self: Any, response: Any) -> Any:
+    def patched_process_response(self: Any, response: Any, model_request_parameters: Any = None) -> Any:
         """Patched version that applies guard_tool_call_id like Chat API."""
-        result = original_process_response(self, response)
+        # Call original with all provided arguments
+        if model_request_parameters is not None:
+            result = original_process_response(self, response, model_request_parameters)
+        else:
+            result = original_process_response(self, response)
 
         # Apply guard_tool_call_id to all ToolCallPart items for consistency
         for item in result.parts:

--- a/gh_analysis/ai/pydantic_ai_patch.py
+++ b/gh_analysis/ai/pydantic_ai_patch.py
@@ -47,7 +47,9 @@ def apply_pydantic_ai_patch() -> None:
     # Based on context-experiments fix for tool call coordination
     original_process_response = OpenAIResponsesModel._process_response
 
-    def patched_process_response(self: Any, response: Any, model_request_parameters: Any = None) -> Any:
+    def patched_process_response(
+        self: Any, response: Any, model_request_parameters: Any = None
+    ) -> Any:
         """Patched version that applies guard_tool_call_id like Chat API."""
         # Call original with all provided arguments
         if model_request_parameters is not None:

--- a/gh_analysis/runners/summary/utils/base_runner.py
+++ b/gh_analysis/runners/summary/utils/base_runner.py
@@ -218,9 +218,13 @@ class BaseAgentRunner(ABC):
 
         original_process_response = OpenAIResponsesModel._process_response
 
-        def patched_process_response(self, response):
+        def patched_process_response(self, response, model_request_parameters=None):
             """Patched version that applies guard_tool_call_id like Chat Completions API does."""
-            result = original_process_response(self, response)
+            # Call original with all provided arguments
+            if model_request_parameters is not None:
+                result = original_process_response(self, response, model_request_parameters)
+            else:
+                result = original_process_response(self, response)
 
             # Apply guard_tool_call_id to all ToolCallPart items for consistency
             for item in result.parts:

--- a/gh_analysis/runners/summary/utils/base_runner.py
+++ b/gh_analysis/runners/summary/utils/base_runner.py
@@ -222,7 +222,9 @@ class BaseAgentRunner(ABC):
             """Patched version that applies guard_tool_call_id like Chat Completions API does."""
             # Call original with all provided arguments
             if model_request_parameters is not None:
-                result = original_process_response(self, response, model_request_parameters)
+                result = original_process_response(
+                    self, response, model_request_parameters
+                )
             else:
                 result = original_process_response(self, response)
 


### PR DESCRIPTION
Running `v run gh-analysis store-summary store --url  xxx` resulted in

```
❌ Agent failures: product: product-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; symptoms: symptoms-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; evidence: evidence-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; cause: cause-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; fix: fix-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; confidence: confidence-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given
❌ Error: Summary generation failed: ❌ Agent failures: product: product-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; symptoms: symptoms-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 
positional arguments but 3 were given; evidence: evidence-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; cause: cause-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 
were given; fix: fix-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given; confidence: confidence-agent run failed: BaseAgentRunner._apply_openai_responses_patch.<locals>.patched_process_response() takes 2 positional arguments but 3 were given
```

This change patches the appropriate spots.